### PR TITLE
Add conversation sidebar with touched_by grouping

### DIFF
--- a/app/src/client/routes/chat-page.tsx
+++ b/app/src/client/routes/chat-page.tsx
@@ -21,6 +21,8 @@ import type {
   SearchEntityResponse,
   StreamEvent as ChatStreamEvent,
   WorkspaceBootstrapResponse,
+  WorkspaceConversationSidebarResponse,
+  WorkspaceConversationResponse,
 } from "../../shared/contracts";
 import { chatComponentCatalog } from "../chat-component-catalog";
 
@@ -75,6 +77,8 @@ export function ChatPage() {
   ]);
   const [activeSessionId] = useState("main");
   const [backendConversationId, setBackendConversationId] = useState<string | undefined>();
+  const [activeConversationId, setActiveConversationId] = useState<string | undefined>();
+  const [sidebar, setSidebar] = useState<WorkspaceConversationSidebarResponse | undefined>();
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
   const [seedItems, setSeedItems] = useState<OnboardingSeedItem[]>([]);
@@ -102,6 +106,85 @@ export function ChatPage() {
 
   if (!activeSession) {
     throw new Error("active session missing");
+  }
+
+  async function refreshSidebar(workspaceId: string) {
+    try {
+      const response = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/sidebar`);
+      if (response.ok) {
+        const payload = (await response.json()) as WorkspaceConversationSidebarResponse;
+        setSidebar(payload);
+      }
+    } catch {
+      // Sidebar refresh is non-critical; silently ignore
+    }
+  }
+
+  async function loadConversation(workspaceId: string, conversationId: string) {
+    try {
+      const response = await fetch(
+        `/api/workspaces/${encodeURIComponent(workspaceId)}/conversations/${encodeURIComponent(conversationId)}`,
+      );
+      if (!response.ok) {
+        const body = await response.text();
+        setErrorMessage(body);
+        return;
+      }
+
+      const payload = (await response.json()) as WorkspaceConversationResponse;
+      const conversations: Session["conversations"] = [];
+      let latestSuggestions: string[] = [];
+
+      for (const message of payload.messages) {
+        if (message.role === "user") {
+          conversations.push({
+            id: message.id,
+            question: message.text,
+            createdAt: new Date(message.createdAt),
+          });
+          continue;
+        }
+
+        const last = conversations[conversations.length - 1];
+        if (last && !last.response) {
+          last.response = message.text;
+          last.updatedAt = new Date(message.createdAt);
+          latestSuggestions = message.suggestions && message.suggestions.length > 0 ? message.suggestions : [];
+          continue;
+        }
+
+        conversations.push({
+          id: `assistant-${message.id}`,
+          question: "System kickoff",
+          response: message.text,
+          createdAt: new Date(message.createdAt),
+        });
+        latestSuggestions = message.suggestions && message.suggestions.length > 0 ? message.suggestions : [];
+      }
+
+      setSessions([
+        {
+          id: "main",
+          title: workspace?.name ?? "Workspace Chat",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          conversations,
+        },
+      ]);
+
+      setSuggestions(
+        latestSuggestions.map((content, index) => ({
+          id: `conv-suggestion-${index}-${content}`,
+          content,
+        })),
+      );
+
+      setActiveConversationId(conversationId);
+      setBackendConversationId(conversationId);
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : "Failed to load conversation";
+      setErrorMessage(messageText);
+    }
   }
 
   async function bootstrapWorkspace(workspaceId: string) {
@@ -183,6 +266,8 @@ export function ChatPage() {
       })),
     );
     setBackendConversationId(payload.conversationId);
+    setActiveConversationId(payload.conversationId);
+    setSidebar(payload.sidebar);
     setWorkspace({
       id: payload.workspaceId,
       name: payload.workspaceName,
@@ -190,6 +275,30 @@ export function ChatPage() {
       onboardingState: payload.onboardingState,
       conversationId: payload.conversationId,
     });
+  }
+
+  function onNewConversation() {
+    setActiveConversationId(undefined);
+    setBackendConversationId(undefined);
+    setSessions([
+      {
+        id: "main",
+        title: workspace?.name ?? "Workspace Chat",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        conversations: [],
+      },
+    ]);
+    setSuggestions([]);
+    setErrorMessage(undefined);
+  }
+
+  function onSelectConversation(conversationId: string) {
+    if (conversationId === activeConversationId || isLoading || !workspace) {
+      return;
+    }
+
+    void loadConversation(workspace.id, conversationId);
   }
 
   async function searchMentions(query: string): Promise<MentionItem[]> {
@@ -394,7 +503,12 @@ export function ChatPage() {
     }
 
     const payload = (await response.json()) as ChatMessageResponse;
+    const isNewConversation = !backendConversationId;
     setBackendConversationId(payload.conversationId);
+    if (isNewConversation) {
+      setActiveConversationId(payload.conversationId);
+    }
+
     if (streamRef.current) {
       streamRef.current.close();
       streamRef.current = undefined;
@@ -516,6 +630,11 @@ export function ChatPage() {
         setIsLoading(false);
         stream.close();
         streamRef.current = undefined;
+
+        // Refresh sidebar after stream completes
+        if (workspace) {
+          void refreshSidebar(workspace.id);
+        }
       }
     };
 
@@ -589,90 +708,156 @@ export function ChatPage() {
         ) : undefined}
       </div>
 
-      <div className={`onboarding-layout${isSeedPanelOpen ? " onboarding-layout--with-seeds" : ""}`}>
-        <Chat
-          viewType="chat"
-          sessions={sessions}
-          activeSessionId={activeSession.id}
-          components={chatComponentCatalog}
-          isLoading={isLoading}
-          onSendMessage={onSendMessage}
-          onStopMessage={onStopMessage}
-          onFileUpload={onUploadFile}
-        >
-          <SessionMessagePanel>
-            <SessionMessagesHeader>
-              <div className="reachat-header">Workspace Chat + Extraction</div>
-            </SessionMessagesHeader>
-            <SessionMessages />
-            <ChatSuggestions
-              suggestions={suggestions}
-              onSuggestionClick={(suggestion) => {
-                void onSendMessage(suggestion);
-              }}
-            />
-            {workspace.onboardingState === "summary_pending" ? (
-              <div className="onboarding-action-buttons">
-                <button
-                  type="button"
-                  disabled={isLoading}
-                  onClick={() =>
-                    void onSendMessage("Looks good, let's go.", {
-                      onboardingAction: "finalize_onboarding",
-                    })}
-                >
-                  Looks good, let's go
-                </button>
-                <button
-                  type="button"
-                  disabled={isLoading}
-                  onClick={() =>
-                    void onSendMessage("I want to add more.", {
-                      onboardingAction: "continue_onboarding",
-                    })}
-                >
-                  I want to add more
-                </button>
+      <div className="workspace-layout">
+        <aside className="conversation-sidebar">
+          <button
+            type="button"
+            className="sidebar-new-conversation"
+            onClick={onNewConversation}
+            disabled={isLoading}
+          >
+            New conversation
+          </button>
+
+          {sidebar?.groups.map((group) => (
+            <div key={group.projectId} className="sidebar-project-group">
+              <div className="sidebar-project-header">
+                <span className="sidebar-project-name">{group.projectName}</span>
+                <span className="sidebar-project-count">{group.conversations.length}</span>
               </div>
-            ) : undefined}
-            <div onClickCapture={onChatInputClickCapture}>
-              <ChatInput
-                ref={chatInputRef}
-                placeholder="Discuss tasks, decisions, and questions..."
-                allowedFiles={[".md", ".txt"]}
-                mentions={{
-                  onSearch: searchMentions,
-                }}
-                commands={{
-                  items: COMMAND_ITEMS,
+              {group.featureActivity.length > 0 ? (
+                <div className="sidebar-feature-activity">
+                  {group.featureActivity.map((feature) => (
+                    <span key={feature.featureId} className="sidebar-feature-chip">
+                      {feature.featureName}
+                    </span>
+                  ))}
+                </div>
+              ) : undefined}
+              <ul className="sidebar-conversation-list">
+                {group.conversations.map((conv) => (
+                  <li key={conv.id}>
+                    <button
+                      type="button"
+                      className={`sidebar-conversation-item${conv.id === activeConversationId ? " sidebar-conversation-item--active" : ""}`}
+                      onClick={() => onSelectConversation(conv.id)}
+                    >
+                      {conv.title}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          {sidebar && sidebar.unlinked.length > 0 ? (
+            <div className="sidebar-project-group">
+              <div className="sidebar-project-header">
+                <span className="sidebar-project-name sidebar-unlinked-label">Unlinked</span>
+                <span className="sidebar-project-count">{sidebar.unlinked.length}</span>
+              </div>
+              <ul className="sidebar-conversation-list">
+                {sidebar.unlinked.map((conv) => (
+                  <li key={conv.id}>
+                    <button
+                      type="button"
+                      className={`sidebar-conversation-item${conv.id === activeConversationId ? " sidebar-conversation-item--active" : ""}`}
+                      onClick={() => onSelectConversation(conv.id)}
+                    >
+                      {conv.title}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : undefined}
+        </aside>
+
+        <div className={`chat-main${isSeedPanelOpen ? " chat-main--with-seeds" : ""}`}>
+          <Chat
+            viewType="chat"
+            sessions={sessions}
+            activeSessionId={activeSession.id}
+            components={chatComponentCatalog}
+            isLoading={isLoading}
+            onSendMessage={onSendMessage}
+            onStopMessage={onStopMessage}
+            onFileUpload={onUploadFile}
+          >
+            <SessionMessagePanel>
+              <SessionMessagesHeader>
+                <div className="reachat-header">Workspace Chat + Extraction</div>
+              </SessionMessagesHeader>
+              <SessionMessages />
+              <ChatSuggestions
+                suggestions={suggestions}
+                onSuggestionClick={(suggestion) => {
+                  void onSendMessage(suggestion);
                 }}
               />
-            </div>
-          </SessionMessagePanel>
-        </Chat>
-
-        {isSeedPanelOpen ? (
-          <aside className="seed-panel">
-            <h3>Live Graph Seed</h3>
-            <p>Entities extracted during onboarding and document ingestion.</p>
-            <ul>
-              {seedItems.map((seed) => (
-                <li key={`${seed.id}:${seed.sourceKind}:${seed.sourceId}`}>
+              {workspace.onboardingState === "summary_pending" ? (
+                <div className="onboarding-action-buttons">
                   <button
                     type="button"
+                    disabled={isLoading}
+                    onClick={() =>
+                      void onSendMessage("Looks good, let's go.", {
+                        onboardingAction: "finalize_onboarding",
+                      })}
                   >
-                    <span className="seed-kind">{seed.kind}</span>
-                    <span className="seed-text">{seed.text}</span>
-                    <span className="seed-meta">
-                      {seed.confidence.toFixed(2)} · {seed.sourceKind}
-                    </span>
-                    {seed.sourceLabel ? <span className="seed-label">{seed.sourceLabel}</span> : undefined}
+                    Looks good, let's go
                   </button>
-                </li>
-              ))}
-            </ul>
-          </aside>
-        ) : undefined}
+                  <button
+                    type="button"
+                    disabled={isLoading}
+                    onClick={() =>
+                      void onSendMessage("I want to add more.", {
+                        onboardingAction: "continue_onboarding",
+                      })}
+                  >
+                    I want to add more
+                  </button>
+                </div>
+              ) : undefined}
+              <div onClickCapture={onChatInputClickCapture}>
+                <ChatInput
+                  ref={chatInputRef}
+                  placeholder="Discuss tasks, decisions, and questions..."
+                  allowedFiles={[".md", ".txt"]}
+                  mentions={{
+                    onSearch: searchMentions,
+                  }}
+                  commands={{
+                    items: COMMAND_ITEMS,
+                  }}
+                />
+              </div>
+            </SessionMessagePanel>
+          </Chat>
+
+          {isSeedPanelOpen ? (
+            <aside className="seed-panel">
+              <h3>Live Graph Seed</h3>
+              <p>Entities extracted during onboarding and document ingestion.</p>
+              <ul>
+                {seedItems.map((seed) => (
+                  <li key={`${seed.id}:${seed.sourceKind}:${seed.sourceId}`}>
+                    <button
+                      type="button"
+                    >
+                      <span className="seed-kind">{seed.kind}</span>
+                      <span className="seed-text">{seed.text}</span>
+                      <span className="seed-meta">
+                        {seed.confidence.toFixed(2)} · {seed.sourceKind}
+                      </span>
+                      {seed.sourceLabel ? <span className="seed-label">{seed.sourceLabel}</span> : undefined}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </aside>
+          ) : undefined}
+        </div>
       </div>
 
       {errorMessage ? <p className="error-message">{errorMessage}</p> : undefined}

--- a/app/src/client/styles.css
+++ b/app/src/client/styles.css
@@ -14,7 +14,7 @@ body {
 }
 
 .app-shell {
-  width: min(1100px, 100%);
+  width: min(1340px, 100%);
   margin: 0 auto;
   padding: 1.5rem 1rem 2.2rem;
 }
@@ -122,15 +122,138 @@ body {
   border-color: #c2d4ea;
 }
 
-.onboarding-layout {
+.workspace-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: 240px minmax(0, 1fr);
   gap: 0.75rem;
   min-height: 64vh;
 }
 
-.onboarding-layout--with-seeds {
+.chat-main {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.chat-main--with-seeds {
   grid-template-columns: minmax(0, 1fr) 280px;
+}
+
+/* Conversation sidebar */
+.conversation-sidebar {
+  border: 1px solid #c7daf2;
+  border-radius: 14px;
+  background: #fbfdff;
+  padding: 0.5rem;
+  overflow-y: auto;
+  max-height: 72vh;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.sidebar-new-conversation {
+  width: 100%;
+  border: 1px solid #9fbfe4;
+  border-radius: 10px;
+  background: #1f6ad1;
+  color: #fff;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  margin-bottom: 0.25rem;
+}
+
+.sidebar-new-conversation:disabled {
+  background: #97b4d9;
+  cursor: not-allowed;
+}
+
+.sidebar-project-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.sidebar-project-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.3rem 0.4rem;
+}
+
+.sidebar-project-name {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #1f4f80;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.sidebar-unlinked-label {
+  color: #6a7e94;
+}
+
+.sidebar-project-count {
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: #4e6784;
+  background: #e5f0ff;
+  border-radius: 999px;
+  padding: 0.1rem 0.38rem;
+}
+
+.sidebar-feature-activity {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.2rem;
+  padding: 0 0.4rem 0.2rem;
+}
+
+.sidebar-feature-chip {
+  display: inline-flex;
+  border-radius: 999px;
+  background: #e5f2ff;
+  color: #0f4f89;
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 0.1rem 0.35rem;
+}
+
+.sidebar-conversation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.sidebar-conversation-item {
+  width: 100%;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.76rem;
+  color: #2a4a6b;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-conversation-item:hover {
+  background: #e8f1fd;
+}
+
+.sidebar-conversation-item--active {
+  background: #d0e3fc;
+  color: #0e3d6e;
+  font-weight: 600;
 }
 
 .seed-panel {
@@ -413,12 +536,16 @@ body {
     padding: 0.35rem;
   }
 
-  .onboarding-layout {
+  .workspace-layout {
     grid-template-columns: 1fr;
   }
 
-  .onboarding-layout--with-seeds {
+  .chat-main--with-seeds {
     grid-template-columns: 1fr;
+  }
+
+  .conversation-sidebar {
+    max-height: 30vh;
   }
 
   .seed-panel ul {

--- a/app/src/server/chat/chat-ingress.ts
+++ b/app/src/server/chat/chat-ingress.ts
@@ -8,6 +8,7 @@ import { jsonError, jsonResponse } from "../http/response";
 import type { ServerDependencies } from "../runtime/types";
 import type { ConversationRow, WorkspaceRow } from "../extraction/types";
 import { resolveWorkspaceRecord } from "../workspace/workspace-scope";
+import { deriveMessageTitle } from "../workspace/conversation-sidebar";
 import { processChatMessage } from "./chat-processor";
 
 export function createChatIngressHandlers(deps: ServerDependencies): {
@@ -89,6 +90,8 @@ async function handlePostChatMessage(deps: ServerDependencies, request: Request)
           createdAt: now,
           updatedAt: now,
           workspace: workspaceRecord,
+          title: deriveMessageTitle(messageText),
+          title_source: "message",
           ...(workspace.onboarding_complete ? {} : { source: "onboarding" }),
         });
       }

--- a/app/src/server/chat/chat-processor.ts
+++ b/app/src/server/chat/chat-processor.ts
@@ -13,6 +13,7 @@ import { generateOnboardingAssistantReply } from "../onboarding/onboarding-reply
 import type { ServerDependencies } from "../runtime/types";
 import { runGraphAwareChat } from "./handler";
 import { getWorkspaceOwnerRecord } from "../graph/queries";
+import { refreshConversationTouchedBy, maybeUpgradeConversationTitle } from "../workspace/conversation-sidebar";
 
 export async function processChatMessage(input: {
   deps: ServerDependencies;
@@ -121,6 +122,9 @@ export async function processChatMessage(input: {
 
     const dedupedTools = [...new Set(extractedTools.map((tool) => tool.trim()).filter((tool) => tool.length > 0))];
     await appendExtractedTools(input.deps.surreal, input.workspaceRecord, extractedTools, now);
+
+    await refreshConversationTouchedBy(input.deps.surreal, conversationRecord);
+    await maybeUpgradeConversationTitle(input.deps.surreal, conversationRecord);
 
     const onboardingBefore = workspace.onboarding_complete
       ? "complete"

--- a/app/src/server/extraction/types.ts
+++ b/app/src/server/extraction/types.ts
@@ -78,6 +78,8 @@ export type ConversationRow = {
   updatedAt: Date | string;
   workspace: RecordId<"workspace", string>;
   source?: string;
+  title?: string;
+  title_source?: "message" | "entity";
 };
 
 export type IncomingAttachment = {

--- a/app/src/server/runtime/start-server.ts
+++ b/app/src/server/runtime/start-server.ts
@@ -46,6 +46,24 @@ export async function startServer(): Promise<void> {
           (request) => workspaceHandlers.handleWorkspaceBootstrap(request.params.workspaceId),
         ),
       },
+      "/api/workspaces/:workspaceId/sidebar": {
+        GET: withRequestLogging(
+          "GET /api/workspaces/:workspaceId/sidebar",
+          "GET",
+          (request) => workspaceHandlers.handleWorkspaceSidebar(request.params.workspaceId),
+        ),
+      },
+      "/api/workspaces/:workspaceId/conversations/:conversationId": {
+        GET: withRequestLogging(
+          "GET /api/workspaces/:workspaceId/conversations/:conversationId",
+          "GET",
+          (request) =>
+            workspaceHandlers.handleWorkspaceConversation(
+              request.params.workspaceId,
+              request.params.conversationId,
+            ),
+        ),
+      },
       "/api/chat/messages": {
         POST: withRequestLogging("POST /api/chat/messages", "POST", (request) => chatHandlers.handlePostChatMessage(request)),
       },

--- a/app/src/server/workspace/conversation-sidebar.ts
+++ b/app/src/server/workspace/conversation-sidebar.ts
@@ -1,0 +1,506 @@
+import { randomUUID } from "node:crypto";
+import { RecordId, type Surreal } from "surrealdb";
+import type {
+  ConversationSidebarItem,
+  ProjectConversationGroup,
+  ProjectFeatureActivity,
+  WorkspaceConversationSidebarResponse,
+} from "../../shared/contracts";
+import type { GraphEntityRecord } from "../extraction/types";
+import { toIsoString } from "../http/response";
+import { logInfo } from "../http/observability";
+
+// ── Pure functions (exported for unit testing) ──────────────────────────
+
+export type TouchedByEdge = {
+  projectId: string;
+  conversationId: string;
+  entityCount: number;
+  firstMentionAt: string;
+};
+
+export type ConversationGroupInput = {
+  id: string;
+  title?: string;
+  updatedAt: string;
+  touchedBy: Array<{ projectId: string; entityCount: number }>;
+};
+
+export type GroupingResult = {
+  groups: Map<string, ConversationSidebarItem[]>;
+  unlinked: ConversationSidebarItem[];
+};
+
+/**
+ * Groups conversations by dominant project using strict majority heuristic.
+ * A conversation is assigned to a project only if that project's entity_count
+ * is strictly greater than half of the total entity count across all projects.
+ */
+export function groupConversationsByProject(conversations: ConversationGroupInput[]): GroupingResult {
+  const groups = new Map<string, ConversationSidebarItem[]>();
+  const unlinked: ConversationSidebarItem[] = [];
+
+  for (const conv of conversations) {
+    const item: ConversationSidebarItem = {
+      id: conv.id,
+      title: conv.title ?? "Untitled",
+      updatedAt: conv.updatedAt,
+    };
+
+    if (conv.touchedBy.length === 0) {
+      unlinked.push(item);
+      continue;
+    }
+
+    const total = conv.touchedBy.reduce((sum, edge) => sum + edge.entityCount, 0);
+    let topEdge = conv.touchedBy[0];
+    for (const edge of conv.touchedBy) {
+      if (edge.entityCount > topEdge.entityCount) {
+        topEdge = edge;
+      }
+    }
+
+    if (topEdge.entityCount > total / 2) {
+      const existing = groups.get(topEdge.projectId) ?? [];
+      existing.push(item);
+      groups.set(topEdge.projectId, existing);
+    } else {
+      unlinked.push(item);
+    }
+  }
+
+  return { groups, unlinked };
+}
+
+/**
+ * Derives the initial title for a conversation from the first user message.
+ */
+export function deriveMessageTitle(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= 72) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, 69)}...`;
+}
+
+export type TitleUpgradeInput = {
+  titleSource?: "message" | "entity";
+  entityTexts: Array<{ kind: string; text: string }>;
+  dominantProjectName?: string;
+};
+
+/**
+ * Determines whether a conversation title should be upgraded and returns
+ * the new title if so. Returns undefined if no upgrade should happen.
+ */
+export function computeTitleUpgrade(input: TitleUpgradeInput): string | undefined {
+  if (input.titleSource !== "message") {
+    return undefined;
+  }
+
+  const qualifying = input.entityTexts.filter(
+    (entity) => entity.kind !== "person" && entity.kind !== "workspace",
+  );
+
+  if (qualifying.length < 3) {
+    return undefined;
+  }
+
+  if (input.dominantProjectName) {
+    return deriveMessageTitle(input.dominantProjectName);
+  }
+
+  // Use the most common entity text as fallback
+  const counts = new Map<string, number>();
+  for (const entity of qualifying) {
+    const key = entity.text.toLowerCase();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  let bestText = qualifying[0].text;
+  let bestCount = 0;
+  for (const [key, count] of counts) {
+    if (count > bestCount) {
+      bestCount = count;
+      bestText = qualifying.find((e) => e.text.toLowerCase() === key)?.text ?? bestText;
+    }
+  }
+
+  return deriveMessageTitle(bestText);
+}
+
+// ── Entity-to-project resolution ────────────────────────────────────────
+
+type ExtractionEdgeRow = {
+  out: GraphEntityRecord;
+  extracted_at: Date | string;
+};
+
+type BelongsToRow = {
+  out: RecordId<string, string> & { tb: string };
+};
+
+type HasFeatureRow = {
+  in: RecordId<"project", string>;
+};
+
+/**
+ * Resolves which project(s) an extracted entity belongs to.
+ * Returns a map of projectId -> { entityIds, earliestExtractedAt }.
+ */
+async function resolveEntityToProjects(
+  surreal: Surreal,
+  entityRecord: GraphEntityRecord,
+): Promise<RecordId<"project", string>[]> {
+  const table = entityRecord.tb;
+
+  if (table === "project") {
+    return [entityRecord as unknown as RecordId<"project", string>];
+  }
+
+  if (table === "feature") {
+    const [rows] = await surreal
+      .query<[HasFeatureRow[]]>(
+        "SELECT `in` FROM has_feature WHERE out = $feature;",
+        { feature: entityRecord },
+      )
+      .collect<[HasFeatureRow[]]>();
+    return rows.map((row) => row.in);
+  }
+
+  if (table === "task" || table === "decision" || table === "question") {
+    const [belongsToRows] = await surreal
+      .query<[BelongsToRow[]]>(
+        "SELECT out FROM belongs_to WHERE `in` = $entity;",
+        { entity: entityRecord },
+      )
+      .collect<[BelongsToRow[]]>();
+
+    const projects: RecordId<"project", string>[] = [];
+
+    for (const row of belongsToRows) {
+      if (row.out.tb === "project") {
+        projects.push(row.out as RecordId<"project", string>);
+      } else if (row.out.tb === "feature") {
+        const [featureRows] = await surreal
+          .query<[HasFeatureRow[]]>(
+            "SELECT `in` FROM has_feature WHERE out = $feature;",
+            { feature: row.out },
+          )
+          .collect<[HasFeatureRow[]]>();
+        projects.push(...featureRows.map((r) => r.in));
+      }
+    }
+
+    return projects;
+  }
+
+  // person, workspace, and other kinds do not contribute
+  return [];
+}
+
+// ── Database operations ─────────────────────────────────────────────────
+
+type TouchedByRow = {
+  id: RecordId<"touched_by", string>;
+  in: RecordId<"project", string>;
+  out: RecordId<"conversation", string>;
+  entity_count: number;
+  first_mention_at: Date | string;
+};
+
+/**
+ * Refreshes the touched_by edges for a conversation based on its extraction_relation rows.
+ */
+export async function refreshConversationTouchedBy(
+  surreal: Surreal,
+  conversationRecord: RecordId<"conversation", string>,
+): Promise<void> {
+  const [extractionRows] = await surreal
+    .query<[ExtractionEdgeRow[]]>(
+      "SELECT out, extracted_at FROM extraction_relation WHERE `in` IN (SELECT VALUE id FROM message WHERE conversation = $conversation);",
+      { conversation: conversationRecord },
+    )
+    .collect<[ExtractionEdgeRow[]]>();
+
+  // Aggregate: projectId -> { uniqueEntityIds, earliestExtractedAt }
+  const projectAgg = new Map<string, { entityIds: Set<string>; earliestAt: Date }>();
+
+  for (const row of extractionRows) {
+    const projects = await resolveEntityToProjects(surreal, row.out);
+    const extractedAt = row.extracted_at instanceof Date ? row.extracted_at : new Date(row.extracted_at as string);
+    const entityId = `${row.out.tb}:${row.out.id}`;
+
+    for (const projectRecord of projects) {
+      const projectId = projectRecord.id as string;
+      const existing = projectAgg.get(projectId);
+      if (existing) {
+        existing.entityIds.add(entityId);
+        if (extractedAt < existing.earliestAt) {
+          existing.earliestAt = extractedAt;
+        }
+      } else {
+        projectAgg.set(projectId, {
+          entityIds: new Set([entityId]),
+          earliestAt: extractedAt,
+        });
+      }
+    }
+  }
+
+  // Load existing touched_by edges for this conversation
+  const [existingEdges] = await surreal
+    .query<[TouchedByRow[]]>(
+      "SELECT id, `in`, out, entity_count, first_mention_at FROM touched_by WHERE out = $conversation;",
+      { conversation: conversationRecord },
+    )
+    .collect<[TouchedByRow[]]>();
+
+  const existingByProject = new Map<string, TouchedByRow>();
+  for (const edge of existingEdges) {
+    existingByProject.set(edge.in.id as string, edge);
+  }
+
+  // Upsert edges for current project aggregations
+  for (const [projectId, agg] of projectAgg) {
+    const existing = existingByProject.get(projectId);
+    const entityCount = agg.entityIds.size;
+
+    if (existing) {
+      await surreal.update(existing.id).merge({
+        entity_count: entityCount,
+        first_mention_at: agg.earliestAt,
+      });
+      existingByProject.delete(projectId);
+    } else {
+      const projectRecord = new RecordId("project", projectId);
+      await surreal.relate(
+        projectRecord,
+        new RecordId("touched_by", randomUUID()),
+        conversationRecord,
+        {
+          first_mention_at: agg.earliestAt,
+          entity_count: entityCount,
+        },
+      ).output("after");
+    }
+  }
+
+  // Remove stale edges (projects no longer represented)
+  for (const staleEdge of existingByProject.values()) {
+    await surreal.delete(staleEdge.id);
+  }
+
+  logInfo("conversation.touched_by.refreshed", "Refreshed touched_by edges", {
+    conversationId: conversationRecord.id as string,
+    projectCount: projectAgg.size,
+    removedCount: existingByProject.size,
+  });
+}
+
+/**
+ * Upgrades a conversation title if conditions are met (title_source === "message",
+ * >= 3 qualifying entities extracted).
+ */
+export async function maybeUpgradeConversationTitle(
+  surreal: Surreal,
+  conversationRecord: RecordId<"conversation", string>,
+): Promise<void> {
+  const conversation = await surreal.select<{
+    title?: string;
+    title_source?: "message" | "entity";
+  }>(conversationRecord);
+
+  if (!conversation || conversation.title_source !== "message") {
+    return;
+  }
+
+  // Count qualifying extracted entities for this conversation
+  const [entityRows] = await surreal
+    .query<[Array<{ out: GraphEntityRecord }>]>(
+      "SELECT out FROM extraction_relation WHERE `in` IN (SELECT VALUE id FROM message WHERE conversation = $conversation);",
+      { conversation: conversationRecord },
+    )
+    .collect<[Array<{ out: GraphEntityRecord }>]>();
+
+  const uniqueEntities = new Map<string, { kind: string; text: string }>();
+  for (const row of entityRows) {
+    const key = `${row.out.tb}:${row.out.id}`;
+    if (!uniqueEntities.has(key)) {
+      uniqueEntities.set(key, { kind: row.out.tb, text: "" });
+    }
+  }
+
+  const qualifying = [...uniqueEntities.values()].filter(
+    (e) => e.kind !== "person" && e.kind !== "workspace",
+  );
+
+  if (qualifying.length < 3) {
+    return;
+  }
+
+  // Check for dominant project via touched_by
+  const [touchedByRows] = await surreal
+    .query<[Array<{ in: RecordId<"project", string>; entity_count: number }>]>(
+      "SELECT `in`, entity_count FROM touched_by WHERE out = $conversation;",
+      { conversation: conversationRecord },
+    )
+    .collect<[Array<{ in: RecordId<"project", string>; entity_count: number }>]>();
+
+  let dominantProjectName: string | undefined;
+  if (touchedByRows.length > 0) {
+    const total = touchedByRows.reduce((sum, row) => sum + row.entity_count, 0);
+    let topRow = touchedByRows[0];
+    for (const row of touchedByRows) {
+      if (row.entity_count > topRow.entity_count) {
+        topRow = row;
+      }
+    }
+
+    if (topRow.entity_count > total / 2) {
+      const project = await surreal.select<{ name: string }>(topRow.in);
+      if (project) {
+        dominantProjectName = project.name;
+      }
+    }
+  }
+
+  // Get entity texts for fallback title
+  const entityTexts: Array<{ kind: string; text: string }> = [];
+  for (const [, entry] of uniqueEntities) {
+    entityTexts.push(entry);
+  }
+
+  // Need actual texts from entities
+  const entityTextRows: Array<{ kind: string; text: string }> = [];
+  for (const row of entityRows) {
+    const kind = row.out.tb;
+    if (kind === "person" || kind === "workspace") continue;
+
+    const textField = kind === "task" ? "title" : kind === "decision" ? "summary" : "text";
+    const entity = await surreal.select<Record<string, string>>(row.out);
+    if (entity) {
+      const text = entity[textField] ?? entity.name ?? "";
+      entityTextRows.push({ kind, text });
+    }
+  }
+
+  const newTitle = computeTitleUpgrade({
+    titleSource: "message",
+    entityTexts: entityTextRows,
+    dominantProjectName,
+  });
+
+  if (newTitle) {
+    await surreal.update(conversationRecord).merge({
+      title: newTitle,
+      title_source: "entity" as const,
+    });
+
+    logInfo("conversation.title.upgraded", "Upgraded conversation title", {
+      conversationId: conversationRecord.id as string,
+      newTitle,
+    });
+  }
+}
+
+// ── Sidebar builder ─────────────────────────────────────────────────────
+
+type ConversationSidebarRow = {
+  id: RecordId<"conversation", string>;
+  title?: string;
+  updatedAt: Date | string;
+};
+
+type FeatureActivityRow = {
+  featureId: RecordId<"feature", string>;
+  featureName: string;
+  latestActivityAt: Date | string;
+};
+
+export async function buildWorkspaceConversationSidebar(
+  surreal: Surreal,
+  workspaceRecord: RecordId<"workspace", string>,
+): Promise<WorkspaceConversationSidebarResponse> {
+  // Load all conversations for this workspace
+  const [conversationRows] = await surreal
+    .query<[ConversationSidebarRow[]]>(
+      "SELECT id, title, updatedAt FROM conversation WHERE workspace = $workspace ORDER BY updatedAt DESC;",
+      { workspace: workspaceRecord },
+    )
+    .collect<[ConversationSidebarRow[]]>();
+
+  // Load all touched_by edges for these conversations
+  const conversationIds = conversationRows.map((row) => row.id);
+  const [touchedByRows] = await surreal
+    .query<[TouchedByRow[]]>(
+      "SELECT id, `in`, out, entity_count, first_mention_at FROM touched_by WHERE out IN $conversations;",
+      { conversations: conversationIds },
+    )
+    .collect<[TouchedByRow[]]>();
+
+  // Build touched_by lookup by conversation
+  const touchedByMap = new Map<string, Array<{ projectId: string; entityCount: number }>>();
+  for (const row of touchedByRows) {
+    const convId = row.out.id as string;
+    const existing = touchedByMap.get(convId) ?? [];
+    existing.push({ projectId: row.in.id as string, entityCount: row.entity_count });
+    touchedByMap.set(convId, existing);
+  }
+
+  // Build conversation input for grouping
+  const conversationInputs: ConversationGroupInput[] = conversationRows.map((row) => ({
+    id: row.id.id as string,
+    title: row.title,
+    updatedAt: toIsoString(row.updatedAt),
+    touchedBy: touchedByMap.get(row.id.id as string) ?? [],
+  }));
+
+  const { groups, unlinked } = groupConversationsByProject(conversationInputs);
+
+  // Load project names and build groups
+  const projectGroups: ProjectConversationGroup[] = [];
+  for (const [projectId, conversations] of groups) {
+    const projectRecord = new RecordId("project", projectId);
+    const project = await surreal.select<{ name: string }>(projectRecord);
+    if (!project) continue;
+
+    const featureActivity = await loadProjectFeatureActivity(surreal, projectRecord, conversations);
+
+    projectGroups.push({
+      projectId,
+      projectName: project.name,
+      conversations,
+      featureActivity,
+    });
+  }
+
+  return { groups: projectGroups, unlinked };
+}
+
+async function loadProjectFeatureActivity(
+  surreal: Surreal,
+  projectRecord: RecordId<"project", string>,
+  _conversations: ConversationSidebarItem[],
+): Promise<ProjectFeatureActivity[]> {
+  // Get features for this project with latest extraction activity
+  const [rows] = await surreal
+    .query<[FeatureActivityRow[]]>(
+      [
+        "SELECT out.id AS featureId, out.name AS featureName, math::max(extracted_at) AS latestActivityAt",
+        "FROM extraction_relation",
+        "WHERE out IN (SELECT VALUE out FROM has_feature WHERE `in` = $project)",
+        "GROUP BY out",
+        "ORDER BY latestActivityAt DESC",
+        "LIMIT 5;",
+      ].join(" "),
+      { project: projectRecord },
+    )
+    .collect<[FeatureActivityRow[]]>();
+
+  return rows.map((row) => ({
+    featureId: (row.featureId as unknown as RecordId<"feature", string>).id as string,
+    featureName: row.featureName,
+    latestActivityAt: toIsoString(row.latestActivityAt),
+  }));
+}

--- a/app/src/server/workspace/workspace-routes.ts
+++ b/app/src/server/workspace/workspace-routes.ts
@@ -5,6 +5,7 @@ import type {
   OnboardingSeedItem,
   WorkspaceBootstrapMessage,
   WorkspaceBootstrapResponse,
+  WorkspaceConversationResponse,
   SourceKind,
   EntityKind,
 } from "../../shared/contracts";
@@ -18,6 +19,7 @@ import { jsonError, jsonResponse, toIsoString } from "../http/response";
 import type { ServerDependencies } from "../runtime/types";
 import { toOnboardingState } from "../onboarding/onboarding-state";
 import { resolveWorkspaceRecord } from "./workspace-scope";
+import { buildWorkspaceConversationSidebar } from "./conversation-sidebar";
 
 type WorkspaceRow = {
   id: RecordId<"workspace", string>;
@@ -47,10 +49,15 @@ type ProvenanceEdgeRow = {
 export function createWorkspaceRouteHandlers(deps: ServerDependencies): {
   handleCreateWorkspace: (request: Request) => Promise<Response>;
   handleWorkspaceBootstrap: (workspaceId: string) => Promise<Response>;
+  handleWorkspaceSidebar: (workspaceId: string) => Promise<Response>;
+  handleWorkspaceConversation: (workspaceId: string, conversationId: string) => Promise<Response>;
 } {
   return {
     handleCreateWorkspace: (request: Request) => handleCreateWorkspace(deps, request),
     handleWorkspaceBootstrap: (workspaceId: string) => handleWorkspaceBootstrap(deps, workspaceId),
+    handleWorkspaceSidebar: (workspaceId: string) => handleWorkspaceSidebar(deps, workspaceId),
+    handleWorkspaceConversation: (workspaceId: string, conversationId: string) =>
+      handleWorkspaceConversation(deps, workspaceId, conversationId),
   };
 }
 
@@ -129,6 +136,8 @@ async function handleCreateWorkspace(deps: ServerDependencies, request: Request)
       updatedAt: now,
       workspace: workspaceRecord,
       source: "onboarding",
+      title: "Onboarding",
+      title_source: "message",
     });
 
     await transaction.create(starterMessageRecord).content({
@@ -197,6 +206,7 @@ async function handleWorkspaceBootstrap(deps: ServerDependencies, workspaceId: s
 
     const seeds = await loadWorkspaceSeeds(deps, workspaceRecord, 40);
     const onboardingState = toOnboardingState(workspace);
+    const sidebar = await buildWorkspaceConversationSidebar(deps.surreal, workspaceRecord);
 
     const payload: WorkspaceBootstrapResponse = {
       workspaceId: workspace.id.id as string,
@@ -206,6 +216,7 @@ async function handleWorkspaceBootstrap(deps: ServerDependencies, workspaceId: s
       conversationId: conversationRecord.id as string,
       messages,
       seeds,
+      sidebar,
     };
 
     logInfo("workspace.bootstrap.completed", "Workspace bootstrap completed", {
@@ -353,4 +364,109 @@ async function readSourceLabel(deps: ServerDependencies, sourceRecord: SourceRec
   }
 
   return document.name;
+}
+
+async function handleWorkspaceSidebar(deps: ServerDependencies, workspaceId: string): Promise<Response> {
+  const startedAt = performance.now();
+  logInfo("workspace.sidebar.started", "Workspace sidebar request started", { workspaceId });
+
+  try {
+    const workspaceRecord = await resolveWorkspaceRecord(deps.surreal, workspaceId);
+    const sidebar = await buildWorkspaceConversationSidebar(deps.surreal, workspaceRecord);
+
+    logInfo("workspace.sidebar.completed", "Workspace sidebar request completed", {
+      workspaceId,
+      groupCount: sidebar.groups.length,
+      unlinkedCount: sidebar.unlinked.length,
+      durationMs: elapsedMs(startedAt),
+    });
+
+    return jsonResponse(sidebar, 200);
+  } catch (error) {
+    if (error instanceof HttpError) {
+      logWarn("workspace.sidebar.http_error", "Workspace sidebar failed with client-facing error", {
+        workspaceId,
+        statusCode: error.status,
+      });
+      return jsonError(error.message, error.status);
+    }
+
+    logError("workspace.sidebar.failed", "Workspace sidebar request failed", error, { workspaceId });
+    const errorText = error instanceof Error ? error.message : "workspace sidebar failed";
+    return jsonError(errorText, 500);
+  }
+}
+
+async function handleWorkspaceConversation(
+  deps: ServerDependencies,
+  workspaceId: string,
+  conversationId: string,
+): Promise<Response> {
+  const startedAt = performance.now();
+  logInfo("workspace.conversation.started", "Workspace conversation request started", {
+    workspaceId,
+    conversationId,
+  });
+
+  try {
+    const workspaceRecord = await resolveWorkspaceRecord(deps.surreal, workspaceId);
+    const conversationRecord = new RecordId("conversation", conversationId);
+    const conversation = await deps.surreal.select<{
+      id: RecordId<"conversation", string>;
+      workspace: RecordId<"workspace", string>;
+    }>(conversationRecord);
+
+    if (!conversation) {
+      throw new HttpError(404, `conversation not found: ${conversationId}`);
+    }
+
+    if ((conversation.workspace.id as string) !== (workspaceRecord.id as string)) {
+      throw new HttpError(400, "conversation does not belong to workspace");
+    }
+
+    const [messageRows] = await deps.surreal
+      .query<[MessageContextRow[]]>(
+        "SELECT id, role, text, createdAt, suggestions FROM message WHERE conversation = $conversation ORDER BY createdAt ASC LIMIT 80;",
+        { conversation: conversationRecord },
+      )
+      .collect<[MessageContextRow[]]>();
+
+    const messages = messageRows.map((row) => ({
+      id: row.id.id as string,
+      role: row.role,
+      text: row.text,
+      createdAt: toIsoString(row.createdAt),
+      ...(row.suggestions && row.suggestions.length > 0 ? { suggestions: row.suggestions } : {}),
+    } satisfies WorkspaceBootstrapMessage));
+
+    const payload: WorkspaceConversationResponse = {
+      conversationId,
+      messages,
+    };
+
+    logInfo("workspace.conversation.completed", "Workspace conversation request completed", {
+      workspaceId,
+      conversationId,
+      messageCount: messages.length,
+      durationMs: elapsedMs(startedAt),
+    });
+
+    return jsonResponse(payload, 200);
+  } catch (error) {
+    if (error instanceof HttpError) {
+      logWarn("workspace.conversation.http_error", "Workspace conversation failed with client-facing error", {
+        workspaceId,
+        conversationId,
+        statusCode: error.status,
+      });
+      return jsonError(error.message, error.status);
+    }
+
+    logError("workspace.conversation.failed", "Workspace conversation request failed", error, {
+      workspaceId,
+      conversationId,
+    });
+    const errorText = error instanceof Error ? error.message : "workspace conversation failed";
+    return jsonError(errorText, 500);
+  }
 }

--- a/app/src/shared/contracts.ts
+++ b/app/src/shared/contracts.ts
@@ -73,6 +73,35 @@ export type WorkspaceBootstrapMessage = {
   suggestions?: string[];
 };
 
+export type ConversationSidebarItem = {
+  id: string;
+  title: string;
+  updatedAt: string;
+};
+
+export type ProjectFeatureActivity = {
+  featureId: string;
+  featureName: string;
+  latestActivityAt: string;
+};
+
+export type ProjectConversationGroup = {
+  projectId: string;
+  projectName: string;
+  conversations: ConversationSidebarItem[];
+  featureActivity: ProjectFeatureActivity[];
+};
+
+export type WorkspaceConversationSidebarResponse = {
+  groups: ProjectConversationGroup[];
+  unlinked: ConversationSidebarItem[];
+};
+
+export type WorkspaceConversationResponse = {
+  conversationId: string;
+  messages: WorkspaceBootstrapMessage[];
+};
+
 export type WorkspaceBootstrapResponse = {
   workspaceId: string;
   workspaceName: string;
@@ -81,6 +110,7 @@ export type WorkspaceBootstrapResponse = {
   conversationId: string;
   messages: WorkspaceBootstrapMessage[];
   seeds: OnboardingSeedItem[];
+  sidebar: WorkspaceConversationSidebarResponse;
 };
 
 export type TokenEvent = {

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "bun install",
+    "archive": "rm -rf node_modules"
+  }
+}

--- a/schema/surreal-schema.surql
+++ b/schema/surreal-schema.surql
@@ -5,8 +5,11 @@ DEFINE FIELD workspace ON conversation TYPE record<workspace>;
 DEFINE FIELD source ON conversation TYPE option<string>;
 DEFINE FIELD timestamp ON conversation TYPE option<datetime>;
 DEFINE FIELD messages ON conversation TYPE option<array<record<message>>>;
+DEFINE FIELD title ON conversation TYPE option<string>;
+DEFINE FIELD title_source ON conversation TYPE option<string> ASSERT $value = NONE OR $value IN ["message", "entity"];
 DEFINE FIELD embedding ON conversation TYPE option<array<float>>;
 DEFINE INDEX conversation_createdAt ON conversation FIELDS createdAt;
+DEFINE INDEX conversation_workspace ON conversation FIELDS workspace;
 
 DEFINE TABLE message SCHEMAFULL;
 DEFINE FIELD conversation ON message TYPE record<conversation>;
@@ -252,6 +255,12 @@ DEFINE FIELD added_at ON decided_in TYPE option<datetime>;
 
 DEFINE TABLE belongs_to TYPE RELATION IN task | decision | question OUT feature | project SCHEMAFULL;
 DEFINE FIELD added_at ON belongs_to TYPE datetime;
+
+DEFINE TABLE touched_by TYPE RELATION IN project OUT conversation SCHEMAFULL;
+DEFINE FIELD first_mention_at ON touched_by TYPE datetime;
+DEFINE FIELD entity_count ON touched_by TYPE int ASSERT $value >= 1;
+DEFINE INDEX touched_by_unique ON touched_by FIELDS `in`, out UNIQUE;
+DEFINE INDEX touched_by_out ON touched_by FIELDS out;
 
 DEFINE TABLE conflicts_with TYPE RELATION IN decision | feature OUT decision | feature SCHEMAFULL;
 DEFINE FIELD description ON conflicts_with TYPE option<string>;

--- a/tests/smoke/conversation-sidebar.test.ts
+++ b/tests/smoke/conversation-sidebar.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+
+type ChatMessageResponse = {
+  messageId: string;
+  userMessageId: string;
+  conversationId: string;
+  workspaceId: string;
+  streamUrl: string;
+};
+
+type SidebarResponse = {
+  groups: Array<{
+    projectId: string;
+    projectName: string;
+    conversations: Array<{ id: string; title: string; updatedAt: string }>;
+    featureActivity: Array<{ featureId: string; featureName: string; latestActivityAt: string }>;
+  }>;
+  unlinked: Array<{ id: string; title: string; updatedAt: string }>;
+};
+
+type ConversationResponse = {
+  conversationId: string;
+  messages: Array<{
+    id: string;
+    role: string;
+    text: string;
+    createdAt: string;
+  }>;
+};
+
+type BootstrapResponse = {
+  workspaceId: string;
+  workspaceName: string;
+  conversationId: string;
+  sidebar: SidebarResponse;
+};
+
+type StreamEvent =
+  | { type: "done"; messageId: string }
+  | { type: "error"; messageId: string; error: string }
+  | { type: string; messageId: string };
+
+const getRuntime = setupSmokeSuite("conversation-sidebar");
+
+async function sendMessageAndWait(
+  baseUrl: string,
+  workspaceId: string,
+  conversationId: string | undefined,
+  text: string,
+): Promise<ChatMessageResponse> {
+  const chatResponse = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      clientMessageId: randomUUID(),
+      workspaceId,
+      text,
+      ...(conversationId ? { conversationId } : {}),
+    }),
+  });
+
+  await collectSseEvents<StreamEvent>(`${baseUrl}${chatResponse.streamUrl}`, 60_000);
+  return chatResponse;
+}
+
+describe("conversation sidebar smoke", () => {
+  it("returns sidebar in bootstrap and via dedicated endpoint", async () => {
+    const { baseUrl } = getRuntime();
+
+    // Create workspace
+    const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(
+      `${baseUrl}/api/workspaces`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: `Sidebar Smoke ${Date.now()}`,
+          ownerDisplayName: "Marcus",
+        }),
+      },
+    );
+
+    // Send a message with extraction-worthy content
+    await sendMessageAndWait(
+      baseUrl,
+      workspace.workspaceId,
+      workspace.conversationId,
+      "Task: implement the authentication module for the Brain platform. Decision: use JWT tokens for session management. Feature: user authentication with OAuth2 support.",
+    );
+
+    // Check sidebar endpoint
+    const sidebar = await fetchJson<SidebarResponse>(
+      `${baseUrl}/api/workspaces/${workspace.workspaceId}/sidebar`,
+    );
+
+    // Should have conversations (either grouped or unlinked)
+    const totalConversations =
+      sidebar.groups.reduce((sum, group) => sum + group.conversations.length, 0) +
+      sidebar.unlinked.length;
+
+    expect(totalConversations).toBeGreaterThan(0);
+
+    // Check bootstrap includes sidebar
+    const bootstrap = await fetchJson<BootstrapResponse>(
+      `${baseUrl}/api/workspaces/${workspace.workspaceId}/bootstrap`,
+    );
+
+    expect(bootstrap.sidebar).toBeDefined();
+    expect(Array.isArray(bootstrap.sidebar.groups)).toBe(true);
+    expect(Array.isArray(bootstrap.sidebar.unlinked)).toBe(true);
+  }, 120_000);
+
+  it("creates a new conversation when conversationId is omitted", async () => {
+    const { baseUrl } = getRuntime();
+
+    // Create workspace
+    const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(
+      `${baseUrl}/api/workspaces`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: `NewConv Smoke ${Date.now()}`,
+          ownerDisplayName: "Marcus",
+        }),
+      },
+    );
+
+    // Send message WITHOUT conversationId — should create a new conversation
+    const chatResponse = await sendMessageAndWait(
+      baseUrl,
+      workspace.workspaceId,
+      undefined,
+      "New conversation about the deployment pipeline",
+    );
+
+    expect(chatResponse.conversationId).toBeDefined();
+    expect(chatResponse.conversationId.length).toBeGreaterThan(0);
+
+    // Verify the new conversation is loadable
+    const convResponse = await fetchJson<ConversationResponse>(
+      `${baseUrl}/api/workspaces/${workspace.workspaceId}/conversations/${chatResponse.conversationId}`,
+    );
+
+    expect(convResponse.conversationId).toBe(chatResponse.conversationId);
+    expect(convResponse.messages.length).toBeGreaterThan(0);
+  }, 120_000);
+
+  it("conversation endpoint returns messages for existing conversation", async () => {
+    const { baseUrl } = getRuntime();
+
+    const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(
+      `${baseUrl}/api/workspaces`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: `ConvLoad Smoke ${Date.now()}`,
+          ownerDisplayName: "Marcus",
+        }),
+      },
+    );
+
+    // Send a message to the onboarding conversation
+    await sendMessageAndWait(
+      baseUrl,
+      workspace.workspaceId,
+      workspace.conversationId,
+      "Testing conversation loading",
+    );
+
+    // Load the conversation via dedicated endpoint
+    const convResponse = await fetchJson<ConversationResponse>(
+      `${baseUrl}/api/workspaces/${workspace.workspaceId}/conversations/${workspace.conversationId}`,
+    );
+
+    expect(convResponse.conversationId).toBe(workspace.conversationId);
+    // Should have at least starter message + user message + assistant response
+    expect(convResponse.messages.length).toBeGreaterThanOrEqual(3);
+  }, 120_000);
+});

--- a/tests/unit/conversation-sidebar-grouping.test.ts
+++ b/tests/unit/conversation-sidebar-grouping.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import {
+  groupConversationsByProject,
+  type ConversationGroupInput,
+} from "../../app/src/server/workspace/conversation-sidebar";
+
+describe("conversation sidebar grouping", () => {
+  const now = new Date().toISOString();
+
+  it("groups a single-project conversation under that project", () => {
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Planning session",
+        updatedAt: now,
+        touchedBy: [{ projectId: "proj-a", entityCount: 5 }],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+    expect(result.groups.get("proj-a")![0].id).toBe("conv-1");
+    expect(result.unlinked).toHaveLength(0);
+  });
+
+  it("puts a conversation with no touched_by edges in unlinked", () => {
+    const conversations: ConversationGroupInput[] = [
+      { id: "conv-1", title: "Random chat", updatedAt: now, touchedBy: [] },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    expect(result.groups.size).toBe(0);
+    expect(result.unlinked).toHaveLength(1);
+    expect(result.unlinked[0].id).toBe("conv-1");
+  });
+
+  it("uses strict majority: top must be > 50%", () => {
+    // Exactly 50% is NOT a strict majority
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Split conversation",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 3 },
+          { projectId: "proj-b", entityCount: 3 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    expect(result.groups.size).toBe(0);
+    expect(result.unlinked).toHaveLength(1);
+  });
+
+  it("groups under dominant project when strict majority exists", () => {
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Mostly project A",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 4 },
+          { projectId: "proj-b", entityCount: 3 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+    expect(result.unlinked).toHaveLength(0);
+  });
+
+  it("multi-project without majority goes to unlinked", () => {
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Three-way split",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 2 },
+          { projectId: "proj-b", entityCount: 2 },
+          { projectId: "proj-c", entityCount: 2 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    expect(result.groups.size).toBe(0);
+    expect(result.unlinked).toHaveLength(1);
+  });
+
+  it("each conversation appears in exactly one location", () => {
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Grouped",
+        updatedAt: now,
+        touchedBy: [{ projectId: "proj-a", entityCount: 5 }],
+      },
+      {
+        id: "conv-2",
+        title: "Unlinked",
+        updatedAt: now,
+        touchedBy: [],
+      },
+      {
+        id: "conv-3",
+        title: "Also grouped",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 3 },
+          { projectId: "proj-b", entityCount: 1 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    const allIds = [
+      ...(result.groups.get("proj-a") ?? []).map((c) => c.id),
+      ...result.unlinked.map((c) => c.id),
+    ];
+
+    expect(allIds).toHaveLength(3);
+    expect(new Set(allIds).size).toBe(3);
+  });
+
+  it("uses 'Untitled' fallback when title is missing", () => {
+    const conversations: ConversationGroupInput[] = [
+      { id: "conv-1", updatedAt: now, touchedBy: [] },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.unlinked[0].title).toBe("Untitled");
+  });
+
+  it("groups multiple conversations under different projects", () => {
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Project A chat",
+        updatedAt: now,
+        touchedBy: [{ projectId: "proj-a", entityCount: 5 }],
+      },
+      {
+        id: "conv-2",
+        title: "Project B chat",
+        updatedAt: now,
+        touchedBy: [{ projectId: "proj-b", entityCount: 8 }],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+    expect(result.groups.get("proj-b")).toHaveLength(1);
+    expect(result.unlinked).toHaveLength(0);
+  });
+});

--- a/tests/unit/conversation-title-derivation.test.ts
+++ b/tests/unit/conversation-title-derivation.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import {
+  deriveMessageTitle,
+  computeTitleUpgrade,
+  type TitleUpgradeInput,
+} from "../../app/src/server/workspace/conversation-sidebar";
+
+describe("conversation title derivation", () => {
+  describe("deriveMessageTitle", () => {
+    it("returns short text as-is", () => {
+      expect(deriveMessageTitle("Planning the auth flow")).toBe("Planning the auth flow");
+    });
+
+    it("trims whitespace", () => {
+      expect(deriveMessageTitle("  hello  ")).toBe("hello");
+    });
+
+    it("truncates text longer than 72 characters", () => {
+      const longText = "A".repeat(100);
+      const result = deriveMessageTitle(longText);
+      expect(result.length).toBe(72);
+      expect(result.endsWith("...")).toBe(true);
+    });
+
+    it("does not truncate text exactly 72 characters", () => {
+      const exact = "B".repeat(72);
+      expect(deriveMessageTitle(exact)).toBe(exact);
+    });
+  });
+
+  describe("computeTitleUpgrade", () => {
+    it("returns undefined when title_source is not 'message'", () => {
+      const input: TitleUpgradeInput = {
+        titleSource: "entity",
+        entityTexts: [
+          { kind: "task", text: "a" },
+          { kind: "task", text: "b" },
+          { kind: "task", text: "c" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(input)).toBeUndefined();
+    });
+
+    it("returns undefined when title_source is undefined", () => {
+      const input: TitleUpgradeInput = {
+        entityTexts: [
+          { kind: "task", text: "a" },
+          { kind: "task", text: "b" },
+          { kind: "task", text: "c" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(input)).toBeUndefined();
+    });
+
+    it("returns undefined when fewer than 3 qualifying entities", () => {
+      const input: TitleUpgradeInput = {
+        titleSource: "message",
+        entityTexts: [
+          { kind: "task", text: "first" },
+          { kind: "decision", text: "second" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(input)).toBeUndefined();
+    });
+
+    it("does not count person entities toward threshold", () => {
+      const input: TitleUpgradeInput = {
+        titleSource: "message",
+        entityTexts: [
+          { kind: "task", text: "only task" },
+          { kind: "person", text: "Alice" },
+          { kind: "person", text: "Bob" },
+          { kind: "person", text: "Carol" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(input)).toBeUndefined();
+    });
+
+    it("does not count workspace entities toward threshold", () => {
+      const input: TitleUpgradeInput = {
+        titleSource: "message",
+        entityTexts: [
+          { kind: "task", text: "only task" },
+          { kind: "workspace", text: "ws1" },
+          { kind: "workspace", text: "ws2" },
+          { kind: "workspace", text: "ws3" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(input)).toBeUndefined();
+    });
+
+    it("uses dominant project name when available", () => {
+      const input: TitleUpgradeInput = {
+        titleSource: "message",
+        entityTexts: [
+          { kind: "task", text: "setup" },
+          { kind: "decision", text: "use React" },
+          { kind: "feature", text: "auth module" },
+        ],
+        dominantProjectName: "Brain Platform",
+      };
+
+      expect(computeTitleUpgrade(input)).toBe("Brain Platform");
+    });
+
+    it("falls back to dominant entity text without project name", () => {
+      const input: TitleUpgradeInput = {
+        titleSource: "message",
+        entityTexts: [
+          { kind: "task", text: "setup database" },
+          { kind: "task", text: "setup database" },
+          { kind: "decision", text: "use Postgres" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(input)).toBe("setup database");
+    });
+
+    it("title upgrade locks: entity source prevents re-upgrade", () => {
+      // Once title_source is "entity", computeTitleUpgrade returns undefined
+      const firstUpgrade: TitleUpgradeInput = {
+        titleSource: "message",
+        entityTexts: [
+          { kind: "task", text: "a" },
+          { kind: "task", text: "b" },
+          { kind: "feature", text: "c" },
+        ],
+      };
+
+      const result = computeTitleUpgrade(firstUpgrade);
+      expect(result).toBeDefined();
+
+      // Simulating post-upgrade state
+      const afterUpgrade: TitleUpgradeInput = {
+        titleSource: "entity",
+        entityTexts: [
+          { kind: "task", text: "a" },
+          { kind: "task", text: "b" },
+          { kind: "feature", text: "c" },
+          { kind: "decision", text: "d" },
+        ],
+      };
+
+      expect(computeTitleUpgrade(afterUpgrade)).toBeUndefined();
+    });
+  });
+});

--- a/tests/unit/touched-by-derivation.test.ts
+++ b/tests/unit/touched-by-derivation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import {
+  groupConversationsByProject,
+  type ConversationGroupInput,
+} from "../../app/src/server/workspace/conversation-sidebar";
+
+describe("touched_by derivation logic", () => {
+  const now = new Date().toISOString();
+
+  it("entity_count represents unique entity IDs, not raw edge count", () => {
+    // When two different conversations reference the same project with different entity counts,
+    // the grouping should use the per-conversation entity_count (unique entities per project)
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Discussion",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 3 }, // 3 unique entities
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+  });
+
+  it("handles a conversation touching the same project through different entity kinds", () => {
+    // Even if entity_count comes from tasks, features, and decisions all pointing to same project,
+    // it should still be counted as one project touch
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Mixed entities",
+        updatedAt: now,
+        touchedBy: [{ projectId: "proj-a", entityCount: 7 }],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+    expect(result.groups.get("proj-a")![0].title).toBe("Mixed entities");
+  });
+
+  it("correctly computes majority with asymmetric entity distribution", () => {
+    // Project A has 5 entities, Project B has 4 entities
+    // 5 > 9/2 = 4.5, so Project A has strict majority
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Slightly dominant",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 5 },
+          { projectId: "proj-b", entityCount: 4 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+    expect(result.unlinked).toHaveLength(0);
+  });
+
+  it("one entity over half is enough for majority", () => {
+    // 3 > 5/2 = 2.5, strict majority
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Slight edge",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 3 },
+          { projectId: "proj-b", entityCount: 2 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+  });
+
+  it("boundary: entity_count 2 vs 2 is not a majority", () => {
+    // 2 > 4/2 = 2, not strictly greater
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "Tied",
+        updatedAt: now,
+        touchedBy: [
+          { projectId: "proj-a", entityCount: 2 },
+          { projectId: "proj-b", entityCount: 2 },
+        ],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.unlinked).toHaveLength(1);
+  });
+
+  it("single project with entity_count 1 has majority (1 > 1/2)", () => {
+    const conversations: ConversationGroupInput[] = [
+      {
+        id: "conv-1",
+        title: "One entity",
+        updatedAt: now,
+        touchedBy: [{ projectId: "proj-a", entityCount: 1 }],
+      },
+    ];
+
+    const result = groupConversationsByProject(conversations);
+    expect(result.groups.get("proj-a")).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Implements Issue #5: project-grouped conversation sidebar driven by `touched_by` edges, deterministic conversation title generation with one-time upgrade, and multi-conversation navigation.

- Schema: Add `title` and `title_source` fields to conversation; add `touched_by` TYPE RELATION (project → conversation) with entity_count tracking
- Backend: New `conversation-sidebar.ts` module with pure grouping/title logic and database operations
- Processing: Wire sidebar refresh and title upgrade into chat processor after extraction
- Client: Left sidebar with project groups, feature activity, unlinked section, and conversation switching

## Test Plan
- Unit tests: 26 tests across grouping heuristic, title derivation, touched_by logic (all pass)
- Smoke tests: 3 integration tests for sidebar endpoint, new conversation flow, conversation loading
- Full TypeScript compilation clean, all 73 existing unit tests still pass