### PR TITLE
Replace regex markdown chunker with AST-powered semantic splitting

### DIFF
--- a/app/src/server/extraction/document-ingestion.ts
+++ b/app/src/server/extraction/document-ingestion.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from "node:crypto";
 import { RecordId, type Surreal } from "surrealdb";
-import { HttpError } from "../http/errors";
 import { elapsedMs, logError, logInfo } from "../http/observability";
 import { createEmbedding } from "./embedding-writeback";
 import { extractStructuredGraph } from "./extract-graph";
+import { splitDocumentIntoChunks } from "./markdown-chunker";
 import { persistExtractionOutput } from "./persist-extraction";
 import type { IncomingAttachment, PersistExtractionResult, SourceRecord } from "./types";
 
@@ -123,82 +123,4 @@ export async function ingestAttachment(input: {
     });
     throw error;
   }
-}
-
-function splitDocumentIntoChunks(content: string): Array<{ heading?: string; content: string; position: number }> {
-  const normalized = content.replace(/\r\n/g, "\n").trim();
-  if (normalized.length === 0) {
-    throw new HttpError(400, "uploaded file content is empty");
-  }
-
-  const lines = normalized.split("\n");
-  const sections: Array<{ heading?: string; text: string }> = [];
-
-  let currentHeading: string | undefined;
-  let currentLines: string[] = [];
-
-  for (const line of lines) {
-    const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line.trim());
-    if (headingMatch) {
-      if (currentLines.length > 0) {
-        sections.push({
-          heading: currentHeading,
-          text: currentLines.join("\n").trim(),
-        });
-      }
-
-      currentHeading = headingMatch[2].trim();
-      currentLines = [];
-      continue;
-    }
-
-    currentLines.push(line);
-  }
-
-  if (currentLines.length > 0) {
-    sections.push({
-      heading: currentHeading,
-      text: currentLines.join("\n").trim(),
-    });
-  }
-
-  const maxChunkChars = 2400;
-  const chunks: Array<{ heading?: string; content: string; position: number }> = [];
-  let position = 0;
-
-  for (const section of sections) {
-    if (section.text.length === 0) {
-      continue;
-    }
-
-    if (section.text.length <= maxChunkChars) {
-      chunks.push({
-        heading: section.heading,
-        content: section.text,
-        position,
-      });
-      position += 1;
-      continue;
-    }
-
-    let cursor = 0;
-    while (cursor < section.text.length) {
-      const slice = section.text.slice(cursor, cursor + maxChunkChars).trim();
-      if (slice.length > 0) {
-        chunks.push({
-          heading: section.heading,
-          content: slice,
-          position,
-        });
-        position += 1;
-      }
-      cursor += maxChunkChars;
-    }
-  }
-
-  if (chunks.length === 0) {
-    throw new HttpError(400, "uploaded file produced no extractable chunks");
-  }
-
-  return chunks;
 }

--- a/app/src/server/extraction/markdown-chunker.ts
+++ b/app/src/server/extraction/markdown-chunker.ts
@@ -1,0 +1,243 @@
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { gfm } from "micromark-extension-gfm";
+import { gfmFromMarkdown } from "mdast-util-gfm";
+import { toString } from "mdast-util-to-string";
+import type { Blockquote, Code, List, RootContent, Table } from "mdast";
+import { HttpError } from "../http/errors";
+
+export type DocumentChunk = {
+  heading?: string;
+  content: string;
+  position: number;
+};
+
+const MAX_CHUNK_CHARS = 2400;
+
+type Section = {
+  heading?: string;
+  blocks: string[];
+};
+
+export function splitDocumentIntoChunks(content: string): DocumentChunk[] {
+  const normalized = content.replace(/\r\n/g, "\n").trim();
+  if (normalized.length === 0) {
+    throw new HttpError(400, "uploaded file content is empty");
+  }
+
+  const ast = fromMarkdown(normalized, {
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()],
+  });
+
+  const sections = accumulateSections(ast.children);
+  const chunks = packChunks(sections);
+
+  if (chunks.length === 0) {
+    throw new HttpError(400, "uploaded file produced no extractable chunks");
+  }
+
+  return chunks;
+}
+
+function accumulateSections(nodes: RootContent[]): Section[] {
+  const sections: Section[] = [];
+  let currentHeading: string | undefined;
+  let currentBlocks: string[] = [];
+
+  for (const node of nodes) {
+    if (node.type === "heading") {
+      if (currentBlocks.length > 0) {
+        sections.push({ heading: currentHeading, blocks: currentBlocks });
+      }
+      currentHeading = toString(node);
+      currentBlocks = [];
+      continue;
+    }
+
+    const text = nodeToPlaintext(node);
+    if (text) {
+      currentBlocks.push(text);
+    }
+  }
+
+  if (currentBlocks.length > 0) {
+    sections.push({ heading: currentHeading, blocks: currentBlocks });
+  }
+
+  return sections;
+}
+
+function nodeToPlaintext(node: RootContent): string | undefined {
+  switch (node.type) {
+    case "html":
+    case "definition":
+    case "thematicBreak":
+      return undefined;
+    case "code":
+      return codeToPlaintext(node as Code);
+    case "table":
+      return tableToPlaintext(node as Table);
+    case "list":
+      return listToPlaintext(node as List);
+    case "blockquote":
+      return blockquoteToPlaintext(node as Blockquote);
+    default:
+      return toString(node) || undefined;
+  }
+}
+
+function codeToPlaintext(node: Code): string | undefined {
+  if (!node.value) return undefined;
+  return node.lang ? `[${node.lang}]:\n${node.value}` : node.value;
+}
+
+function tableToPlaintext(node: Table): string | undefined {
+  const rows = node.children;
+  if (rows.length === 0) return undefined;
+
+  const headers = rows[0].children.map((cell) => toString(cell));
+  if (rows.length === 1) {
+    return headers.join(", ");
+  }
+
+  const lines: string[] = [];
+  for (let i = 1; i < rows.length; i++) {
+    const cells = rows[i].children;
+    const parts: string[] = [];
+    for (let j = 0; j < cells.length; j++) {
+      const header = headers[j] ?? `Column ${j + 1}`;
+      parts.push(`${header}: ${toString(cells[j])}`);
+    }
+    lines.push(parts.join(", "));
+  }
+  return lines.join("\n") || undefined;
+}
+
+function listToPlaintext(node: List): string | undefined {
+  const lines: string[] = [];
+  for (const item of node.children) {
+    const parts: string[] = [];
+    for (const child of item.children) {
+      if (child.type === "list") {
+        const nested = listToPlaintext(child as List);
+        if (nested) parts.push(nested);
+      } else {
+        const text = toString(child);
+        if (text) parts.push(text);
+      }
+    }
+    if (parts.length > 0) {
+      lines.push(parts.join("\n"));
+    }
+  }
+  return lines.join("\n") || undefined;
+}
+
+function blockquoteToPlaintext(node: Blockquote): string | undefined {
+  const parts: string[] = [];
+  for (const child of node.children) {
+    const text = nodeToPlaintext(child as RootContent);
+    if (text) parts.push(text);
+  }
+  return parts.join("\n") || undefined;
+}
+
+function packChunks(sections: Section[]): DocumentChunk[] {
+  const chunks: DocumentChunk[] = [];
+  let position = 0;
+
+  for (const section of sections) {
+    let accumulator = "";
+
+    for (const block of section.blocks) {
+      const candidate =
+        accumulator.length > 0 ? `${accumulator}\n\n${block}` : block;
+
+      if (candidate.length <= MAX_CHUNK_CHARS) {
+        accumulator = candidate;
+        continue;
+      }
+
+      // Emit current accumulator if non-empty
+      if (accumulator.length > 0) {
+        chunks.push({ heading: section.heading, content: accumulator, position });
+        position++;
+        accumulator = "";
+      }
+
+      // Handle the block that didn't fit
+      if (block.length <= MAX_CHUNK_CHARS) {
+        accumulator = block;
+      } else {
+        const subChunks = splitOversizedBlock(block);
+        for (let i = 0; i < subChunks.length - 1; i++) {
+          chunks.push({ heading: section.heading, content: subChunks[i], position });
+          position++;
+        }
+        accumulator = subChunks[subChunks.length - 1];
+      }
+    }
+
+    if (accumulator.length > 0) {
+      chunks.push({ heading: section.heading, content: accumulator, position });
+      position++;
+    }
+  }
+
+  return chunks;
+}
+
+function splitOversizedBlock(text: string): string[] {
+  // Try splitting at double-newline boundaries first
+  const paragraphs = text.split(/\n\n+/);
+  if (paragraphs.length > 1) {
+    return packStringSegments(paragraphs, "\n\n");
+  }
+
+  // Fall back to single-newline boundaries
+  const lines = text.split("\n");
+  if (lines.length > 1) {
+    return packStringSegments(lines, "\n");
+  }
+
+  // Last resort: character-level splitting
+  const result: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const slice = text.slice(cursor, cursor + MAX_CHUNK_CHARS).trim();
+    if (slice.length > 0) {
+      result.push(slice);
+    }
+    cursor += MAX_CHUNK_CHARS;
+  }
+  return result;
+}
+
+function packStringSegments(segments: string[], separator: string): string[] {
+  const result: string[] = [];
+  let accumulator = "";
+
+  for (const segment of segments) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+
+    const candidate =
+      accumulator.length > 0 ? `${accumulator}${separator}${trimmed}` : trimmed;
+
+    if (candidate.length <= MAX_CHUNK_CHARS) {
+      accumulator = candidate;
+    } else {
+      if (accumulator.length > 0) {
+        result.push(accumulator);
+      }
+      // If single segment exceeds limit, include it anyway (will be split at next level)
+      accumulator = trimmed;
+    }
+  }
+
+  if (accumulator.length > 0) {
+    result.push(accumulator);
+  }
+
+  return result;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,10 @@
         "@openrouter/ai-sdk-provider": "^2.2.3",
         "@tanstack/react-router": "^1.131.24",
         "ai": "^6.0.101",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-gfm": "^3.1.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-extension-gfm": "^3.0.0",
         "pino": "^10.3.1",
         "reachat": "^3.0.0",
         "react": "^19.1.1",
@@ -17,6 +21,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@types/mdast": "^4.0.4",
         "@types/node": "^24.5.2",
         "@types/react": "^19.1.4",
         "@types/react-dom": "^19.1.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "@openrouter/ai-sdk-provider": "^2.2.3",
     "@tanstack/react-router": "^1.131.24",
     "ai": "^6.0.101",
+    "mdast-util-from-markdown": "^2.0.3",
+    "mdast-util-gfm": "^3.1.0",
+    "mdast-util-to-string": "^4.0.0",
+    "micromark-extension-gfm": "^3.0.0",
     "pino": "^10.3.1",
     "reachat": "^3.0.0",
     "react": "^19.1.1",
@@ -30,6 +34,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/mdast": "^4.0.4",
     "@types/node": "^24.5.2",
     "@types/react": "^19.1.4",
     "@types/react-dom": "^19.1.4",

--- a/tests/unit/markdown-chunker.test.ts
+++ b/tests/unit/markdown-chunker.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "bun:test";
+import { splitDocumentIntoChunks } from "../../app/src/server/extraction/markdown-chunker";
+
+describe("splitDocumentIntoChunks", () => {
+  it("splits by heading sections with correct heading metadata", () => {
+    const md = `# Introduction
+
+Some intro text.
+
+## Features
+
+Feature list here.
+
+### Sub-feature
+
+Detail about sub-feature.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks.length).toBe(3);
+    expect(chunks[0].heading).toBe("Introduction");
+    expect(chunks[0].content).toBe("Some intro text.");
+    expect(chunks[1].heading).toBe("Features");
+    expect(chunks[1].content).toBe("Feature list here.");
+    expect(chunks[2].heading).toBe("Sub-feature");
+    expect(chunks[2].content).toBe("Detail about sub-feature.");
+  });
+
+  it("does not treat # inside a fenced code block as a heading", () => {
+    const md = `# Real Heading
+
+Some text before code.
+
+\`\`\`bash
+# This is a comment, not a heading
+echo "hello"
+\`\`\`
+
+More text after code.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    // All content should be under "Real Heading"
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].heading).toBe("Real Heading");
+    expect(chunks[0].content).toContain("This is a comment, not a heading");
+    expect(chunks[0].content).toContain("Some text before code.");
+    expect(chunks[0].content).toContain("More text after code.");
+  });
+
+  it("preserves code block content with language prefix", () => {
+    const md = `# Setup
+
+\`\`\`typescript
+const db = new Surreal();
+await db.connect("ws://localhost:8000");
+\`\`\``;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("[typescript]:");
+    expect(chunks[0].content).toContain("const db = new Surreal();");
+  });
+
+  it("includes code blocks without language as-is", () => {
+    const md = `# Example
+
+\`\`\`
+plain code block
+\`\`\``;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("plain code block");
+    expect(chunks[0].content).not.toContain("[");
+  });
+
+  it("splits oversized sections at paragraph boundaries", () => {
+    const para = "A".repeat(1200);
+    const md = `# Big Section
+
+${para}
+
+${para}
+
+${para}`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.content.length).toBeLessThanOrEqual(2400);
+      expect(chunk.heading).toBe("Big Section");
+    }
+  });
+
+  it("converts table to Header: Value plaintext", () => {
+    const md = `# Data
+
+| Name | Status |
+|------|--------|
+| Alpha | Active |
+| Beta | Paused |`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("Name: Alpha");
+    expect(chunks[0].content).toContain("Status: Active");
+    expect(chunks[0].content).toContain("Name: Beta");
+    expect(chunks[0].content).toContain("Status: Paused");
+  });
+
+  it("strips link URLs, keeps link text", () => {
+    const md = "We chose [SurrealDB](https://surrealdb.com) for the database.";
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("SurrealDB");
+    expect(chunks[0].content).not.toContain("https://surrealdb.com");
+  });
+
+  it("strips image URLs, keeps alt text", () => {
+    const md = "Architecture: ![system diagram](https://example.com/arch.png)";
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("system diagram");
+    expect(chunks[0].content).not.toContain("https://example.com/arch.png");
+  });
+
+  it("strips HTML comments", () => {
+    const md = `# Notes
+
+<!-- TODO: remove this later -->
+
+Actual content here.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toBe("Actual content here.");
+    expect(chunks[0].content).not.toContain("TODO");
+  });
+
+  it("handles plain text without any markdown syntax", () => {
+    const text = "Just a plain text file with no markdown formatting whatsoever.";
+    const chunks = splitDocumentIntoChunks(text);
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].content).toBe(text);
+    expect(chunks[0].heading).toBeUndefined();
+  });
+
+  it("throws on empty content", () => {
+    expect(() => splitDocumentIntoChunks("")).toThrow("uploaded file content is empty");
+    expect(() => splitDocumentIntoChunks("   \n\n  ")).toThrow("uploaded file content is empty");
+  });
+
+  it("never produces chunks exceeding 2400 characters", () => {
+    const longParagraph = "Word ".repeat(600); // ~3000 chars
+    const md = `# Long
+
+${longParagraph}`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    for (const chunk of chunks) {
+      expect(chunk.content.length).toBeLessThanOrEqual(2400);
+    }
+  });
+
+  it("assigns sequential 0-based positions", () => {
+    const md = `# A
+
+Text A.
+
+# B
+
+Text B.
+
+# C
+
+Text C.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks.map((c) => c.position)).toEqual([0, 1, 2]);
+  });
+
+  it("places content before first heading in a section with undefined heading", () => {
+    const md = `Some preamble text.
+
+# First Heading
+
+Content under heading.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].heading).toBeUndefined();
+    expect(chunks[0].content).toBe("Some preamble text.");
+    expect(chunks[1].heading).toBe("First Heading");
+  });
+
+  it("extracts text from GFM task lists", () => {
+    const md = `# Tasks
+
+- [x] Deploy to staging
+- [ ] Write integration tests
+- [ ] Update documentation`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("Deploy to staging");
+    expect(chunks[0].content).toContain("Write integration tests");
+    expect(chunks[0].content).toContain("Update documentation");
+  });
+
+  it("extracts text from nested lists", () => {
+    const md = `# Structure
+
+- Backend
+  - API server
+  - Database layer
+- Frontend
+  - React app`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("Backend");
+    expect(chunks[0].content).toContain("API server");
+    expect(chunks[0].content).toContain("Database layer");
+    expect(chunks[0].content).toContain("Frontend");
+    expect(chunks[0].content).toContain("React app");
+  });
+
+  it("strips link definitions", () => {
+    const md = `Check [the docs][docs] for more info.
+
+[docs]: https://example.com/docs "Documentation"`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("the docs");
+    expect(chunks[0].content).not.toContain("https://example.com/docs");
+  });
+
+  it("does not produce empty chunks for heading-only sections", () => {
+    const md = `# Heading One
+
+# Heading Two
+
+Content under two.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    for (const chunk of chunks) {
+      expect(chunk.content.length).toBeGreaterThan(0);
+    }
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].heading).toBe("Heading Two");
+  });
+
+  it("handles Windows line endings", () => {
+    const md = "# Title\r\n\r\nContent with CRLF.\r\n";
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].heading).toBe("Title");
+    expect(chunks[0].content).toBe("Content with CRLF.");
+  });
+
+  it("handles blockquotes", () => {
+    const md = `# Quotes
+
+> This is an important decision.
+> We chose to use SurrealDB.`;
+
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("This is an important decision.");
+    expect(chunks[0].content).toContain("We chose to use SurrealDB.");
+  });
+
+  it("strips bold and italic markers", () => {
+    const md = "We **strongly** recommend using *TypeScript* for the ~~JavaScript~~ rewrite.";
+    const chunks = splitDocumentIntoChunks(md);
+    expect(chunks[0].content).toContain("strongly");
+    expect(chunks[0].content).toContain("TypeScript");
+    expect(chunks[0].content).toContain("JavaScript");
+    expect(chunks[0].content).not.toContain("**");
+    expect(chunks[0].content).not.toContain("*");
+    expect(chunks[0].content).not.toContain("~~");
+  });
+});


### PR DESCRIPTION
## Summary

Introduced `mdast-util-from-markdown` with GFM support to replace regex-based markdown parsing. The new chunker provides code-block immunity (headings inside fenced code no longer create section splits), semantic chunk boundaries (paragraphs instead of fixed 2,400-char cuts), and clean plaintext output for the extraction LLM.

## Changes

- **New module**: `app/src/server/extraction/markdown-chunker.ts` with five-phase AST-based chunking (parse, section accumulation, node-to-plaintext, chunk packing, oversized-block splitting)
- **Improved parsing**: Code blocks preserved with language prefix, tables converted to `Key: Value` plaintext, nested lists flattened, blockquotes handled recursively
- **Noise removal**: HTML comments, link definitions, formatting markers (`**`, `*`, `~~`) stripped automatically
- **Test coverage**: 21 unit tests covering headings, code blocks, tables, links, images, oversized blocks, edge cases
- **Dependencies**: Added explicit mdast packages (already transitive via reachat/prosemirror)

## Testing

Run `bun test tests/unit/markdown-chunker.test.ts` to verify the chunker. Then validate real-world extraction with `bun run smoke:readme-import` and `bun run eval` to confirm extraction quality is maintained or improved.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>