### PR TITLE
Stream extracted entities incrementally during document upload

### DIFF
--- a/app/src/client/routes/chat-page.tsx
+++ b/app/src/client/routes/chat-page.tsx
@@ -545,6 +545,27 @@ export function ChatPage() {
         return;
       }
 
+      if (parsed.type === "extraction") {
+        setSeedItems((existing) => {
+          const deduped = new Map(existing.map((item) => [`${item.id}:${item.sourceKind}:${item.sourceId}`, item]));
+          for (const entity of parsed.entities) {
+            const key = `${entity.id}:${entity.sourceKind}:${entity.sourceId}`;
+            if (!deduped.has(key)) {
+              deduped.set(key, {
+                id: entity.id,
+                kind: entity.kind,
+                text: entity.text,
+                confidence: entity.confidence,
+                sourceKind: entity.sourceKind,
+                sourceId: entity.sourceId,
+              });
+            }
+          }
+          return [...deduped.values()];
+        });
+        return;
+      }
+
       if (parsed.type === "assistant_message") {
         streamedText = parsed.text;
         setSuggestions(

--- a/app/src/server/chat/chat-processor.ts
+++ b/app/src/server/chat/chat-processor.ts
@@ -73,6 +73,23 @@ export async function processChatMessage(input: {
         userMessageRecord: input.userMessageRecord,
         attachment: input.attachment,
         now,
+        onChunkResult: (chunkResult) => {
+          if (chunkResult.entities.length > 0 || chunkResult.relationships.length > 0) {
+            input.deps.sse.emitEvent(input.messageId, {
+              type: "extraction",
+              messageId: input.messageId,
+              entities: chunkResult.entities,
+              relationships: chunkResult.relationships,
+            });
+          }
+          if (chunkResult.seeds.length > 0) {
+            input.deps.sse.emitEvent(input.messageId, {
+              type: "onboarding_seed",
+              messageId: input.messageId,
+              seeds: chunkResult.seeds,
+            });
+          }
+        },
       });
 
       persistedEntities.push(...ingestion.entities);

--- a/app/src/server/extraction/document-ingestion.ts
+++ b/app/src/server/extraction/document-ingestion.ts
@@ -19,6 +19,7 @@ export async function ingestAttachment(input: {
   userMessageRecord: RecordId<"message", string>;
   attachment: IncomingAttachment;
   now: Date;
+  onChunkResult?: (result: PersistExtractionResult) => void;
 }): Promise<PersistExtractionResult> {
   const startedAt = performance.now();
   const documentRecord = new RecordId("document", randomUUID());
@@ -87,6 +88,8 @@ export async function ingestAttachment(input: {
         sourceChunkRecord: chunkRecord,
         now: input.now,
       });
+
+      input.onChunkResult?.(result);
 
       persistedEntities.push(...result.entities);
       persistedRelationships.push(...result.relationships);


### PR DESCRIPTION
## Summary

- Adds an optional `onChunkResult` callback to `ingestAttachment()` so callers can react as each document chunk is processed
- Chat processor now emits incremental `extraction` and `onboarding_seed` SSE events per chunk instead of batching all results until the entire document finishes
- Frontend handles the new incremental `extraction` events with Map-based deduplication, populating the seed panel progressively

## Why

Previously, users uploading multi-section documents saw no extraction feedback until all chunks completed processing. Now entities appear in the seed panel chunk-by-chunk as they're extracted and persisted.

## Test plan

- [ ] Upload a multi-section markdown document and verify entities appear incrementally in the seed panel during processing
- [ ] Verify the final batched extraction event still fires after all chunks complete (text-message entities)
- [ ] Confirm no duplicate entities appear in the seed panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)