### PR TITLE
Migrate RecordId table access from .tb to .table.name SDK API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,13 +180,14 @@ When the PM agent suggests work items, the orchestrator renders them as `WorkIte
 
 - Use `RecordId` objects everywhere for Surreal identifiers (never `table:id` strings).
 - Server extraction types define typed record aliases:
-  - `GraphEntityRecord` and `SourceRecord` include a typed `tb` field for table discrimination.
-- Prefer typed `record.tb` access for table branching; do not use untyped casts like `(record as unknown as { tb: string }).tb`.
+  - `GraphEntityRecord` and `SourceRecord` are `RecordId<UnionOfTables, string>` aliases.
+- Use `record.table.name` for table branching (the SDK's public API; `.tb` is an undeclared internal field that may break on upgrade).
 
 ## SurrealDB SDK v2
 
 Reference: https://surrealdb.com/learn/fundamentals/schemafull/define-fields
 
+- Do NOT use `.tb` on `RecordId` — it works at runtime but is not in the SDK type definition and may break on upgrade. Use `.table.name` instead (returns the same typed `Tb` string via the public API).
 - When using `http://` or `https://` URLs, the SDK uses HTTP transport only. It does NOT attempt WebSocket upgrade.
 - WebSocket is only used when the URL scheme is `ws://` or `wss://`.
 - To CREATE a record with a specific ID, use the SDK's `RecordId` class:

--- a/app/src/server/extraction/context-loaders.ts
+++ b/app/src/server/extraction/context-loaders.ts
@@ -85,7 +85,7 @@ export async function loadConversationGraphContext(
       continue;
     }
 
-    const entityTable = row.out.tb;
+    const entityTable = row.out.table.name;
     if (
       entityTable !== "project" &&
       entityTable !== "person" &&
@@ -131,7 +131,7 @@ export async function loadConversationGraphContext(
       const entityId = row.out.id as string;
       if (seen.has(entityId)) continue;
 
-      const entityTable = row.out.tb;
+      const entityTable = row.out.table.name;
       if (
         entityTable !== "project" &&
         entityTable !== "person" &&
@@ -204,7 +204,7 @@ export async function loadWorkspaceGraphContext(
     const entityId = row.out.id as string;
     if (seen.has(entityId)) continue;
 
-    const entityTable = row.out.tb;
+    const entityTable = row.out.table.name;
     if (
       entityTable !== "project" &&
       entityTable !== "person" &&

--- a/app/src/server/extraction/embedding-writeback.ts
+++ b/app/src/server/extraction/embedding-writeback.ts
@@ -39,7 +39,7 @@ export async function persistEmbeddings(input: {
         surreal: input.surreal,
         record: entity.record as RecordId<string, string>,
         embedding: entityEmbedding,
-        label: `${entity.record.tb}:${entity.record.id as string}`,
+        label: `${entity.record.table.name}:${entity.record.id as string}`,
       });
       embeddedEntityCount += 1;
     }

--- a/app/src/server/extraction/entity-text.ts
+++ b/app/src/server/extraction/entity-text.ts
@@ -2,7 +2,7 @@ import { RecordId, type Surreal } from "surrealdb";
 import type { GraphEntityRecord } from "./types";
 
 export async function readEntityText(surreal: Surreal, record: GraphEntityRecord): Promise<string | undefined> {
-  const table = record.tb;
+  const table = record.table.name;
 
   if (table === "workspace") {
     const row = await surreal.select<{ name: string }>(record as RecordId<"workspace", string>);

--- a/app/src/server/extraction/extract-graph.ts
+++ b/app/src/server/extraction/extract-graph.ts
@@ -100,7 +100,7 @@ function formatExtractionGraphContext(rows: ExtractionGraphContextRow[]): string
 
   return rows
     .map((row) => {
-      const table = row.id.tb;
+      const table = row.id.table.name;
       return `[entity:${table}:${row.id.id as string}] ${row.kind}: ${row.text} (confidence ${row.confidence.toFixed(2)}, source message ${row.sourceMessage.id as string})`;
     })
     .join("\n");

--- a/app/src/server/extraction/types.ts
+++ b/app/src/server/extraction/types.ts
@@ -9,9 +9,8 @@ import type {
 export type ExtractableEntityKind = Exclude<EntityKind, "workspace" | "observation">;
 export type PersistableExtractableEntityKind = Exclude<ExtractableEntityKind, "person">;
 export type GraphEntityTable = "workspace" | "project" | "person" | "feature" | "task" | "decision" | "question" | "observation";
-type TbRecordId<Tb extends string> = RecordId<Tb, string> & { tb: Tb };
-export type GraphEntityRecord = TbRecordId<GraphEntityTable>;
-export type SourceRecord = TbRecordId<"message" | "document_chunk" | "git_commit">;
+export type GraphEntityRecord = RecordId<GraphEntityTable, string>;
+export type SourceRecord = RecordId<"message" | "document_chunk" | "git_commit", string>;
 
 export type MessageContextRow = {
   id: RecordId<"message", string>;

--- a/app/src/server/workspace/conversation-sidebar.ts
+++ b/app/src/server/workspace/conversation-sidebar.ts
@@ -153,7 +153,7 @@ async function resolveEntityToProjects(
   surreal: Surreal,
   entityRecord: GraphEntityRecord,
 ): Promise<RecordId<"project", string>[]> {
-  const table = entityRecord.tb;
+  const table = entityRecord.table.name;
 
   if (table === "project") {
     return [entityRecord as unknown as RecordId<"project", string>];
@@ -180,9 +180,9 @@ async function resolveEntityToProjects(
     const projects: RecordId<"project", string>[] = [];
 
     for (const row of belongsToRows) {
-      if (row.out.tb === "project") {
+      if (row.out.table.name === "project") {
         projects.push(row.out as RecordId<"project", string>);
-      } else if (row.out.tb === "feature") {
+      } else if (row.out.table.name === "feature") {
         const [featureRows] = await surreal
           .query<[HasFeatureRow[]]>(
             "SELECT `in` FROM has_feature WHERE out = $feature;",
@@ -230,7 +230,7 @@ export async function refreshConversationTouchedBy(
   for (const row of extractionRows) {
     const projects = await resolveEntityToProjects(surreal, row.out);
     const extractedAt = row.extracted_at instanceof Date ? row.extracted_at : new Date(row.extracted_at as string);
-    const entityId = `${row.out.tb}:${row.out.id}`;
+    const entityId = `${row.out.table.name}:${row.out.id}`;
 
     for (const projectRecord of projects) {
       const projectId = projectRecord.id as string;
@@ -326,9 +326,9 @@ export async function maybeUpgradeConversationTitle(
 
   const uniqueEntities = new Map<string, { kind: string; text: string }>();
   for (const row of entityRows) {
-    const key = `${row.out.tb}:${row.out.id}`;
+    const key = `${row.out.table.name}:${row.out.id}`;
     if (!uniqueEntities.has(key)) {
-      uniqueEntities.set(key, { kind: row.out.tb, text: "" });
+      uniqueEntities.set(key, { kind: row.out.table.name, text: "" });
     }
   }
 
@@ -375,7 +375,7 @@ export async function maybeUpgradeConversationTitle(
   // Need actual texts from entities
   const entityTextRows: Array<{ kind: string; text: string }> = [];
   for (const row of entityRows) {
-    const kind = row.out.tb;
+    const kind = row.out.table.name;
     if (kind === "person" || kind === "workspace") continue;
 
     const textField = kind === "task" ? "title" : kind === "decision" ? "summary" : "text";

--- a/app/src/server/workspace/workspace-routes.ts
+++ b/app/src/server/workspace/workspace-routes.ts
@@ -304,8 +304,8 @@ async function loadWorkspaceSeeds(
       continue;
     }
 
-    const sourceTable = edge.in.tb;
-    const entityTable = edge.out.tb;
+    const sourceTable = edge.in.table.name;
+    const entityTable = edge.out.table.name;
     const sourceKind = (sourceTable === "document_chunk" ? "document_chunk" : "message") as SourceKind;
     const sourceLabel = await readSourceLabel(deps, edge.in);
 
@@ -324,7 +324,7 @@ async function loadWorkspaceSeeds(
 }
 
 async function readSourceLabel(deps: ServerDependencies, sourceRecord: SourceRecord): Promise<string | undefined> {
-  const sourceTable = sourceRecord.tb;
+  const sourceTable = sourceRecord.table.name;
   if (sourceTable === "message") {
     const row = await deps.surreal.select<{ text: string }>(sourceRecord);
     if (!row) {


### PR DESCRIPTION
## Summary

Replace custom `.tb` property (undeclared internal field) with the official SurrealDB SDK's `.table.name` method across extraction and workspace modules. Remove the `TbRecordId` type augmentation that was adding a runtime `.tb` property to `RecordId` objects. Update `AGENTS.md` to document the new best practice.

## Rationale

Using `.tb` relies on implementation details not exposed in the public SDK type definitions. This refactoring ensures future code uses the official API contract, preventing potential breakage on SDK upgrades.

## Testing

No behavior changes—only API usage updates. Existing tests pass without modification.

Closes https://github.com/marcus-sa/brain/issues/66

🤖 Generated with [Claude Code](https://claude.com/claude-code)