### PR TITLE
Add direct workspace field to entities, simplify scope queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@
 - To represent absence, add a `"none"` sentinel to the enum and strip it to `undefined` via `.transform()` after parsing. The transform is applied during Zod validation but does not affect the JSON schema sent to the provider.
 - Existing pattern: `assignee_name` and `resolvedFromMessageId` use union variants (each variant has the field as required) instead of optional fields.
 
+## Schema & Data Migration
+
+- This project does NOT maintain backwards compatibility with existing data. Schema changes are breaking.
+- Do NOT write data migration or backfill scripts. Old data is discarded on schema changes.
+- New fields should be required (not optional) from the start — no need for `option<...>` to accommodate pre-existing records.
+
 ## Failure Handling
 
 - Do NOT add fallback logic that masks invalid state, malformed payloads, or contract violations.

--- a/app/src/server/chat/tools/create-provisional-decision.ts
+++ b/app/src/server/chat/tools/create-provisional-decision.ts
@@ -49,6 +49,7 @@ export function createCreateProvisionalDecisionTool(deps: ChatToolDeps) {
         summary: input.name,
         status: "provisional",
         now,
+        workspaceRecord: context.workspaceRecord,
         sourceMessageRecord: context.currentMessageRecord,
         rationale: input.rationale,
         ...(input.options_considered && input.options_considered.length > 0

--- a/app/src/server/chat/tools/resolve-decision.ts
+++ b/app/src/server/chat/tools/resolve-decision.ts
@@ -121,6 +121,7 @@ export function createResolveDecisionTool(deps: ChatToolDeps) {
           summary: input.question,
           status: "inferred",
           now,
+          workspaceRecord: context.workspaceRecord,
           sourceMessageRecord: context.currentMessageRecord,
           rationale: `Inferred from existing graph context with ${sources.length} related entities.`,
           ...(input.options && input.options.length > 0 ? { optionsConsidered: input.options } : {}),

--- a/app/src/server/entities/entity-actions-route.ts
+++ b/app/src/server/entities/entity-actions-route.ts
@@ -62,8 +62,7 @@ async function handleEntityAction(
     const table = entityRecord.table.name;
     const now = new Date();
 
-    // Observation actions bypass the standard workspace scope check
-    // because observations have their own workspace field (not graph edges).
+    // Observation actions have separate handlers from task/decision/question.
     if (table === "observation") {
       if (body.action === "acknowledge") {
         await acknowledgeObservation({

--- a/app/src/server/entities/work-item-accept-route.ts
+++ b/app/src/server/entities/work-item-accept-route.ts
@@ -74,6 +74,7 @@ async function handleAcceptWorkItem(
       await deps.surreal.create(taskRecord).content({
         title: item.title,
         status: "open",
+        workspace: workspaceRecord,
         ...(item.category ? { category: item.category } : {}),
         ...(item.priority ? { priority: item.priority } : {}),
         ...(embedding ? { embedding } : {}),

--- a/app/src/server/extraction/entity-upsert.ts
+++ b/app/src/server/extraction/entity-upsert.ts
@@ -122,6 +122,7 @@ export async function upsertGraphEntity(input: {
       input.extracted.text,
       input.extracted.confidence,
       input.now,
+      input.workspaceRecord,
       candidateEmbedding,
       input.sourceMessageRecord,
       input.sourceCommitRecord,
@@ -261,6 +262,7 @@ function buildEntityRecordContent(
   text: string,
   confidence: number,
   now: Date,
+  workspaceRecord: RecordId<"workspace", string>,
   embedding?: number[],
   sourceMessageRecord?: RecordId<"message", string>,
   sourceCommitRecord?: RecordId<"git_commit", string>,
@@ -298,6 +300,7 @@ function buildEntityRecordContent(
       ...(embedding ? { embedding } : {}),
       ...(category ? { category } : {}),
       ...(priority ? { priority } : {}),
+      workspace: workspaceRecord,
       created_at: now,
       updated_at: now,
     };
@@ -314,6 +317,7 @@ function buildEntityRecordContent(
       ...(embedding ? { embedding } : {}),
       ...(category ? { category } : {}),
       ...(priority ? { priority } : {}),
+      workspace: workspaceRecord,
       created_at: now,
       updated_at: now,
     };
@@ -330,6 +334,7 @@ function buildEntityRecordContent(
     ...(embedding ? { embedding } : {}),
     ...(category ? { category } : {}),
     ...(priority ? { priority } : {}),
+    workspace: workspaceRecord,
     created_at: now,
     updated_at: now,
   };
@@ -381,80 +386,30 @@ export async function loadWorkspaceKindCandidates(
   if (kind === "task") {
     const [rows] = await surreal
       .query<[CandidateEntityRow[]]>(
-        [
-          "SELECT id, title AS text, embedding",
-          "FROM task",
-          "WHERE id IN (",
-          "  SELECT VALUE `in`",
-          "  FROM belongs_to",
-          "  WHERE out IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)",
-          ")",
-          "OR source_message IN (",
-          "  SELECT VALUE id",
-          "  FROM message",
-          "  WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-          ")",
-          "OR source_commit IN (SELECT VALUE id FROM git_commit WHERE workspace = $workspace);",
-        ].join(" "),
+        "SELECT id, title AS text, embedding FROM task WHERE workspace = $workspace;",
         { workspace: workspaceRecord },
       )
       .collect<[CandidateEntityRow[]]>();
-    return uniqueCandidateRows(rows);
+    return rows;
   }
 
   if (kind === "decision") {
     const [rows] = await surreal
       .query<[CandidateEntityRow[]]>(
-        [
-          "SELECT id, summary AS text, embedding",
-          "FROM decision",
-          "WHERE id IN (",
-          "  SELECT VALUE `in`",
-          "  FROM belongs_to",
-          "  WHERE out IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)",
-          ")",
-          "OR source_message IN (",
-          "  SELECT VALUE id",
-          "  FROM message",
-          "  WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-          ")",
-          "OR source_commit IN (SELECT VALUE id FROM git_commit WHERE workspace = $workspace);",
-        ].join(" "),
+        "SELECT id, summary AS text, embedding FROM decision WHERE workspace = $workspace;",
         { workspace: workspaceRecord },
       )
       .collect<[CandidateEntityRow[]]>();
-    return uniqueCandidateRows(rows);
+    return rows;
   }
 
   const [rows] = await surreal
     .query<[CandidateEntityRow[]]>(
-      [
-        "SELECT id, text AS text, embedding",
-        "FROM question",
-        "WHERE id IN (",
-        "  SELECT VALUE `in`",
-        "  FROM belongs_to",
-        "  WHERE out IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)",
-        ")",
-        "OR source_message IN (",
-        "  SELECT VALUE id",
-        "  FROM message",
-        "  WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-        ")",
-        "OR source_commit IN (SELECT VALUE id FROM git_commit WHERE workspace = $workspace);",
-      ].join(" "),
+      "SELECT id, text AS text, embedding FROM question WHERE workspace = $workspace;",
       { workspace: workspaceRecord },
     )
     .collect<[CandidateEntityRow[]]>();
-  return uniqueCandidateRows(rows);
-}
-
-function uniqueCandidateRows(rows: CandidateEntityRow[]): CandidateEntityRow[] {
-  const byId = new Map<string, CandidateEntityRow>();
-  for (const row of rows) {
-    byId.set(row.id.id as string, row);
-  }
-  return [...byId.values()];
+  return rows;
 }
 
 export async function appendWorkspaceTools(

--- a/app/src/server/feed/feed-queries.ts
+++ b/app/src/server/feed/feed-queries.ts
@@ -34,22 +34,8 @@ async function getWorkspaceProjectRows(
   return rows;
 }
 
-function buildWorkspaceScopeClause(table: "decision" | "question" | "task"): string {
-  return [
-    "(",
-    "  id IN (SELECT VALUE `in` FROM belongs_to WHERE out IN $projects)",
-    "  OR source_message IN (",
-    "    SELECT VALUE id",
-    "    FROM message",
-    "    WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-    "  )",
-    ...(table === "task"
-      ? [
-          "  OR source_commit IN (SELECT VALUE id FROM git_commit WHERE workspace = $workspace)",
-        ]
-      : []),
-    ")",
-  ].join(" ");
+function buildWorkspaceScopeClause(_table: "decision" | "question" | "task"): string {
+  return "workspace = $workspace";
 }
 
 // --- Blocking tier ---
@@ -161,14 +147,10 @@ export async function listWorkspaceConflicts(input: WorkspaceQueryInput): Promis
       [
         "SELECT id, `in`, out, description, severity, detected_at",
         "FROM conflicts_with",
-        "WHERE `in` IN (",
-        "  SELECT VALUE `in` FROM belongs_to",
-        "  WHERE out IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)",
-        ")",
-        "OR out IN (",
-        "  SELECT VALUE `in` FROM belongs_to",
-        "  WHERE out IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)",
-        ")",
+        "WHERE `in` IN (SELECT VALUE id FROM decision WHERE workspace = $workspace)",
+        "OR `in` IN (SELECT VALUE id FROM feature WHERE id IN (SELECT VALUE out FROM has_feature WHERE `in` IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)))",
+        "OR out IN (SELECT VALUE id FROM decision WHERE workspace = $workspace)",
+        "OR out IN (SELECT VALUE id FROM feature WHERE id IN (SELECT VALUE out FROM has_feature WHERE `in` IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)))",
         "ORDER BY detected_at DESC",
         "LIMIT $limit;",
       ].join(" "),

--- a/app/src/server/graph/queries.ts
+++ b/app/src/server/graph/queries.ts
@@ -287,23 +287,7 @@ export async function isEntityInWorkspace(
   if (table === "task" || table === "decision" || table === "question") {
     const [rows] = await surreal
       .query<[Array<{ id: RecordId<"task" | "decision" | "question", string> }>]>(
-        [
-          "SELECT id",
-          `FROM ${table}`,
-          "WHERE id = $entity",
-          "AND (",
-          "  id IN (",
-          "    SELECT VALUE `in`",
-          "    FROM belongs_to",
-          "    WHERE out IN (SELECT VALUE out FROM has_project WHERE `in` = $workspace)",
-          "  )",
-          "  OR source_message IN (",
-          "    SELECT VALUE id",
-          "    FROM message",
-          "    WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-          "  )",
-          ");",
-        ].join(" "),
+        `SELECT id FROM ${table} WHERE id = $entity AND workspace = $workspace;`,
         { workspace: workspaceRecord, entity: entityRecord },
       )
       .collect<[Array<{ id: RecordId<"task" | "decision" | "question", string> }>]>();
@@ -482,18 +466,12 @@ export async function listWorkspaceRecentDecisions(input: {
       [
         "SELECT id, summary, status, priority, created_at",
         "FROM decision",
-        "WHERE id IN (SELECT VALUE `in` FROM belongs_to WHERE out IN $projects)",
-        "OR source_message IN (",
-        "  SELECT VALUE id",
-        "  FROM message",
-        "  WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-        ")",
+        "WHERE workspace = $workspace",
         "ORDER BY created_at DESC",
         "LIMIT $limit;",
       ].join(" "),
       {
         workspace: input.workspaceRecord,
-        projects: projectRecords,
         limit: input.limit,
       },
     )
@@ -540,21 +518,13 @@ export async function listWorkspaceOpenQuestions(input: {
       [
         "SELECT id, text, status, priority, created_at",
         "FROM question",
-        "WHERE status = 'open'",
-        "AND (",
-        "  id IN (SELECT VALUE `in` FROM belongs_to WHERE out IN $projects)",
-        "  OR source_message IN (",
-        "    SELECT VALUE id",
-        "    FROM message",
-        "    WHERE conversation IN (SELECT VALUE id FROM conversation WHERE workspace = $workspace)",
-        "  )",
-        ")",
+        "WHERE workspace = $workspace",
+        "AND status = 'open'",
         "ORDER BY created_at DESC",
         "LIMIT $limit;",
       ].join(" "),
       {
         workspace: input.workspaceRecord,
-        projects: projectRecords,
         limit: input.limit,
       },
     )
@@ -1279,6 +1249,7 @@ export async function createDecisionRecord(input: {
   summary: string;
   status: string;
   now: Date;
+  workspaceRecord: RecordId<"workspace", string>;
   sourceMessageRecord?: RecordId<"message", string>;
   rationale?: string;
   optionsConsidered?: string[];
@@ -1295,6 +1266,7 @@ export async function createDecisionRecord(input: {
     status: input.status,
     created_at: input.now,
     updated_at: input.now,
+    workspace: input.workspaceRecord,
     ...(input.sourceMessageRecord ? { source_message: input.sourceMessageRecord } : {}),
     ...(input.rationale ? { rationale: input.rationale } : {}),
     ...(input.optionsConsidered && input.optionsConsidered.length > 0

--- a/schema/surreal-schema.surql
+++ b/schema/surreal-schema.surql
@@ -109,7 +109,9 @@ DEFINE FIELD category ON task TYPE option<string>
 DEFINE INDEX task_status_deadline ON task FIELDS status, deadline;
 DEFINE INDEX task_source_message ON task FIELDS source_message;
 DEFINE INDEX task_source_commit ON task FIELDS source_commit;
+DEFINE FIELD workspace ON task TYPE record<workspace>;
 DEFINE INDEX idx_task_embedding ON task FIELDS embedding HNSW DIMENSION 1536 DIST COSINE;
+DEFINE INDEX task_workspace ON task FIELDS workspace;
 
 DEFINE TABLE decision SCHEMAFULL;
 DEFINE FIELD summary ON decision TYPE string;
@@ -138,7 +140,9 @@ DEFINE FIELD priority ON decision TYPE option<string>
 DEFINE INDEX decision_status_decided_at ON decision FIELDS status, decided_at;
 DEFINE INDEX decision_source_message ON decision FIELDS source_message;
 DEFINE INDEX decision_source_commit ON decision FIELDS source_commit;
+DEFINE FIELD workspace ON decision TYPE record<workspace>;
 DEFINE INDEX idx_decision_embedding ON decision FIELDS embedding HNSW DIMENSION 1536 DIST COSINE;
+DEFINE INDEX decision_workspace ON decision FIELDS workspace;
 
 DEFINE TABLE question SCHEMAFULL;
 DEFINE FIELD text ON question TYPE string;
@@ -160,7 +164,9 @@ DEFINE FIELD priority ON question TYPE option<string>
 DEFINE INDEX question_status ON question FIELDS status;
 DEFINE INDEX question_source_message ON question FIELDS source_message;
 DEFINE INDEX question_source_commit ON question FIELDS source_commit;
+DEFINE FIELD workspace ON question TYPE record<workspace>;
 DEFINE INDEX idx_question_embedding ON question FIELDS embedding HNSW DIMENSION 1536 DIST COSINE;
+DEFINE INDEX question_workspace ON question FIELDS workspace;
 
 DEFINE TABLE observation SCHEMAFULL;
 DEFINE FIELD text ON observation TYPE string;
@@ -347,9 +353,6 @@ DEFINE FIELD added_at ON attended_by TYPE option<datetime>;
 DEFINE FUNCTION fn::entity_search_workspace($q: string, $limit: int, $workspace: record<workspace>) {
   LET $query = string::lowercase(string::trim($q));
   LET $safe_limit = math::min([math::max([$limit, 1]), 100]);
-  LET $workspace_conversations = SELECT VALUE id FROM conversation WHERE workspace = $workspace;
-  LET $workspace_messages = SELECT VALUE id FROM message WHERE conversation IN $workspace_conversations;
-  LET $workspace_commits = SELECT VALUE id FROM git_commit WHERE workspace = $workspace;
 
   LET $task_rows = SELECT
     id,
@@ -360,10 +363,7 @@ DEFINE FUNCTION fn::entity_search_workspace($q: string, $limit: int, $workspace:
     priority,
     created_at
   FROM task
-  WHERE (
-      (source_message != NONE AND source_message IN $workspace_messages)
-      OR (source_commit != NONE AND source_commit IN $workspace_commits)
-    )
+  WHERE workspace = $workspace
     AND extraction_confidence != NONE
     AND string::contains(string::lowercase(title), $query)
   ORDER BY created_at DESC
@@ -378,10 +378,7 @@ DEFINE FUNCTION fn::entity_search_workspace($q: string, $limit: int, $workspace:
     priority,
     created_at
   FROM decision
-  WHERE (
-      (source_message != NONE AND source_message IN $workspace_messages)
-      OR (source_commit != NONE AND source_commit IN $workspace_commits)
-    )
+  WHERE workspace = $workspace
     AND extraction_confidence != NONE
     AND string::contains(string::lowercase(summary), $query)
   ORDER BY created_at DESC
@@ -396,10 +393,7 @@ DEFINE FUNCTION fn::entity_search_workspace($q: string, $limit: int, $workspace:
     priority,
     created_at
   FROM question
-  WHERE (
-      (source_message != NONE AND source_message IN $workspace_messages)
-      OR (source_commit != NONE AND source_commit IN $workspace_commits)
-    )
+  WHERE workspace = $workspace
     AND extraction_confidence != NONE
     AND string::contains(string::lowercase(text), $query)
   ORDER BY created_at DESC
@@ -411,9 +405,6 @@ DEFINE FUNCTION fn::entity_search_workspace($q: string, $limit: int, $workspace:
 DEFINE FUNCTION fn::entity_search_project($q: string, $limit: int, $workspace: record<workspace>, $project: record<project>) {
   LET $query = string::lowercase(string::trim($q));
   LET $safe_limit = math::min([math::max([$limit, 1]), 100]);
-  LET $workspace_conversations = SELECT VALUE id FROM conversation WHERE workspace = $workspace;
-  LET $workspace_messages = SELECT VALUE id FROM message WHERE conversation IN $workspace_conversations;
-  LET $workspace_commits = SELECT VALUE id FROM git_commit WHERE workspace = $workspace;
   LET $project_entity_ids = SELECT VALUE `in` FROM belongs_to WHERE out = $project;
 
   LET $task_rows = SELECT
@@ -425,10 +416,7 @@ DEFINE FUNCTION fn::entity_search_project($q: string, $limit: int, $workspace: r
     priority,
     created_at
   FROM task
-  WHERE (
-      (source_message != NONE AND source_message IN $workspace_messages)
-      OR (source_commit != NONE AND source_commit IN $workspace_commits)
-    )
+  WHERE workspace = $workspace
     AND extraction_confidence != NONE
     AND id IN $project_entity_ids
     AND string::contains(string::lowercase(title), $query)
@@ -444,10 +432,7 @@ DEFINE FUNCTION fn::entity_search_project($q: string, $limit: int, $workspace: r
     priority,
     created_at
   FROM decision
-  WHERE (
-      (source_message != NONE AND source_message IN $workspace_messages)
-      OR (source_commit != NONE AND source_commit IN $workspace_commits)
-    )
+  WHERE workspace = $workspace
     AND extraction_confidence != NONE
     AND id IN $project_entity_ids
     AND string::contains(string::lowercase(summary), $query)
@@ -463,10 +448,7 @@ DEFINE FUNCTION fn::entity_search_project($q: string, $limit: int, $workspace: r
     priority,
     created_at
   FROM question
-  WHERE (
-      (source_message != NONE AND source_message IN $workspace_messages)
-      OR (source_commit != NONE AND source_commit IN $workspace_commits)
-    )
+  WHERE workspace = $workspace
     AND extraction_confidence != NONE
     AND id IN $project_entity_ids
     AND string::contains(string::lowercase(text), $query)


### PR DESCRIPTION
## Summary

- Adds a required `workspace` field (with index) to `task`, `decision`, and `question` tables in the SurrealDB schema, enabling direct workspace scoping without multi-hop graph traversals.
- Replaces all workspace scope queries — entity search functions, feed queries, candidate loading, and workspace membership checks — from complex subquery chains (`belongs_to` + `source_message` + `source_commit` lookups) to simple `WHERE workspace = $workspace` clauses.
- Updates all entity creation paths (extraction pipeline, chat tools, work-item accept) to persist the workspace field.
- Removes the `uniqueCandidateRows` dedup helper and `buildWorkspaceScopeClause` multi-hop logic that are no longer needed.
- Documents the no-backwards-compatibility data migration policy in AGENTS.md.

## Test plan

- [ ] Run `bun test tests/unit/` to verify no regressions in unit tests
- [ ] Run `bun test tests/smoke/` against a fresh SurrealDB to confirm schema applies and entity creation/query paths work
- [ ] Verify entity search returns correct workspace-scoped results in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)