### PR TITLE
Workspace owner automatically assigned from authenticated user

### DIFF
--- a/app/src/client/components/layout/WorkspaceGuard.tsx
+++ b/app/src/client/components/layout/WorkspaceGuard.tsx
@@ -6,13 +6,9 @@ type WorkspaceGuardProps = {
   isCreatingWorkspace: boolean;
   canCreateWorkspace: boolean;
   createWorkspaceName: string;
-  createOwnerName: string;
-  createOwnerEmail: string;
   createWorkspaceDescription: string;
   errorMessage?: string;
   setCreateWorkspaceName: (name: string) => void;
-  setCreateOwnerName: (name: string) => void;
-  setCreateOwnerEmail: (email: string) => void;
   setCreateWorkspaceDescription: (description: string) => void;
   onCreateWorkspace: (event: FormEvent<HTMLFormElement>) => void;
   children: ReactNode;
@@ -24,13 +20,9 @@ export function WorkspaceGuard({
   isCreatingWorkspace,
   canCreateWorkspace,
   createWorkspaceName,
-  createOwnerName,
-  createOwnerEmail,
   createWorkspaceDescription,
   errorMessage,
   setCreateWorkspaceName,
-  setCreateOwnerName,
-  setCreateOwnerEmail,
   setCreateWorkspaceDescription,
   onCreateWorkspace,
   children,
@@ -47,7 +39,7 @@ export function WorkspaceGuard({
     return (
       <section className="workspace-setup">
         <h2>Create Workspace</h2>
-        <p>Start with workspace name and owner identity. Onboarding continues in chat.</p>
+        <p>Name your workspace to get started. Onboarding continues in chat.</p>
         <form onSubmit={onCreateWorkspace} className="workspace-form">
           <label>
             Workspace name
@@ -55,25 +47,6 @@ export function WorkspaceGuard({
               value={createWorkspaceName}
               onChange={(event) => setCreateWorkspaceName(event.target.value)}
               placeholder="Acme Labs"
-              required
-            />
-          </label>
-          <label>
-            Owner display name
-            <input
-              value={createOwnerName}
-              onChange={(event) => setCreateOwnerName(event.target.value)}
-              placeholder="Marcus"
-              required
-            />
-          </label>
-          <label>
-            Email
-            <input
-              type="email"
-              value={createOwnerEmail}
-              onChange={(event) => setCreateOwnerEmail(event.target.value)}
-              placeholder="marcus@example.com"
               required
             />
           </label>

--- a/app/src/client/hooks/use-workspace.ts
+++ b/app/src/client/hooks/use-workspace.ts
@@ -16,13 +16,9 @@ type UseWorkspaceReturn = {
   isCreatingWorkspace: boolean;
   errorMessage?: string;
   createWorkspaceName: string;
-  createOwnerName: string;
-  createOwnerEmail: string;
   createWorkspaceDescription: string;
   canCreateWorkspace: boolean;
   setCreateWorkspaceName: (name: string) => void;
-  setCreateOwnerName: (name: string) => void;
-  setCreateOwnerEmail: (email: string) => void;
   setCreateWorkspaceDescription: (description: string) => void;
   onCreateWorkspace: (event: FormEvent<HTMLFormElement>) => void;
 };
@@ -45,14 +41,11 @@ export { parseBootstrapMessages, ACTIVE_WORKSPACE_STORAGE_KEY };
 export function useWorkspace(): UseWorkspaceReturn {
   const store = useWorkspaceState();
   const [createWorkspaceName, setCreateWorkspaceName] = useState("");
-  const [createOwnerName, setCreateOwnerName] = useState("");
-  const [createOwnerEmail, setCreateOwnerEmail] = useState("");
   const [createWorkspaceDescription, setCreateWorkspaceDescription] = useState("");
   const [isCreatingWorkspace, setIsCreatingWorkspace] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
-  const canCreateWorkspace =
-    createWorkspaceName.trim().length > 0 && createOwnerName.trim().length > 0 && createOwnerEmail.trim().length > 0;
+  const canCreateWorkspace = createWorkspaceName.trim().length > 0;
 
   useEffect(() => {
     const existingWorkspaceId = window.localStorage.getItem(ACTIVE_WORKSPACE_STORAGE_KEY);
@@ -112,14 +105,12 @@ export function useWorkspace(): UseWorkspaceReturn {
     event.preventDefault();
 
     const name = createWorkspaceName.trim();
-    const ownerDisplayName = createOwnerName.trim();
-    const ownerEmail = createOwnerEmail.trim();
     if (isCreatingWorkspace) {
       return;
     }
 
-    if (!name || !ownerDisplayName || !ownerEmail) {
-      setErrorMessage("Workspace name, owner display name, and email are required");
+    if (!name) {
+      setErrorMessage("Workspace name is required");
       return;
     }
 
@@ -129,8 +120,6 @@ export function useWorkspace(): UseWorkspaceReturn {
     const description = createWorkspaceDescription.trim();
     const requestBody: CreateWorkspaceRequest = {
       name,
-      ownerDisplayName,
-      ownerEmail,
       ...(description.length > 0 ? { description } : {}),
     };
 
@@ -157,8 +146,6 @@ export function useWorkspace(): UseWorkspaceReturn {
       window.localStorage.setItem(ACTIVE_WORKSPACE_STORAGE_KEY, payload.workspaceId);
       await bootstrapWorkspace(payload.workspaceId);
       setCreateWorkspaceName("");
-      setCreateOwnerName("");
-      setCreateOwnerEmail("");
       setCreateWorkspaceDescription("");
     } catch (error) {
       const messageText = error instanceof Error ? error.message : "Workspace creation failed";
@@ -174,13 +161,9 @@ export function useWorkspace(): UseWorkspaceReturn {
     isCreatingWorkspace,
     errorMessage,
     createWorkspaceName,
-    createOwnerName,
-    createOwnerEmail,
     createWorkspaceDescription,
     canCreateWorkspace,
     setCreateWorkspaceName,
-    setCreateOwnerName,
-    setCreateOwnerEmail,
     setCreateWorkspaceDescription,
     onCreateWorkspace,
   };

--- a/app/src/client/router.tsx
+++ b/app/src/client/router.tsx
@@ -42,13 +42,9 @@ function AppShell() {
       isCreatingWorkspace={workspace.isCreatingWorkspace}
       canCreateWorkspace={workspace.canCreateWorkspace}
       createWorkspaceName={workspace.createWorkspaceName}
-      createOwnerName={workspace.createOwnerName}
-      createOwnerEmail={workspace.createOwnerEmail}
       createWorkspaceDescription={workspace.createWorkspaceDescription}
       errorMessage={workspace.errorMessage}
       setCreateWorkspaceName={workspace.setCreateWorkspaceName}
-      setCreateOwnerName={workspace.setCreateOwnerName}
-      setCreateOwnerEmail={workspace.setCreateOwnerEmail}
       setCreateWorkspaceDescription={workspace.setCreateWorkspaceDescription}
       onCreateWorkspace={workspace.onCreateWorkspace}
     >

--- a/app/src/server/http/parsing.ts
+++ b/app/src/server/http/parsing.ts
@@ -36,22 +36,12 @@ export function parseCreateWorkspaceRequest(body: unknown):
     return { ok: false, error: "name is required" };
   }
 
-  if (!payload.ownerDisplayName || payload.ownerDisplayName.trim().length === 0) {
-    return { ok: false, error: "ownerDisplayName is required" };
-  }
-
-  if (!payload.ownerEmail || payload.ownerEmail.trim().length === 0) {
-    return { ok: false, error: "ownerEmail is required" };
-  }
-
   const description = typeof payload.description === "string" ? payload.description.trim() : undefined;
 
   return {
     ok: true,
     data: {
       name: payload.name.trim(),
-      ownerDisplayName: payload.ownerDisplayName.trim(),
-      ownerEmail: payload.ownerEmail.trim(),
       ...(description && description.length > 0 ? { description } : {}),
     },
   };

--- a/app/src/server/workspace/workspace-routes.ts
+++ b/app/src/server/workspace/workspace-routes.ts
@@ -10,7 +10,6 @@ import type {
   SourceKind,
   EntityKind,
 } from "../../shared/contracts";
-import { createEmbeddingVector } from "../graph/embeddings";
 import { readEntityName } from "../graph/queries";
 import { readEntityText } from "../extraction/entity-text";
 import type { GraphEntityRecord, SourceRecord } from "../extraction/types";
@@ -61,6 +60,11 @@ async function handleCreateWorkspace(deps: ServerDependencies, request: Request)
   const startedAt = performance.now();
   logInfo("workspace.create.started", "Workspace creation started");
 
+  const session = await deps.auth.api.getSession({ headers: request.headers });
+  if (!session?.user?.id) {
+    return jsonError("authentication required", 401);
+  }
+
   let body: unknown;
   try {
     body = await request.json();
@@ -78,13 +82,13 @@ async function handleCreateWorkspace(deps: ServerDependencies, request: Request)
   const now = new Date();
   const workspaceId = randomUUID();
   const conversationId = randomUUID();
-  const ownerId = randomUUID();
 
   const workspaceRecord = new RecordId("workspace", workspaceId);
   const conversationRecord = new RecordId("conversation", conversationId);
-  const ownerRecord = new RecordId("person", ownerId);
+  const ownerRecord = new RecordId("person", session.user.id);
   const starterMessageRecord = new RecordId("message", randomUUID());
   const hasDescription = parsed.data.description !== undefined;
+  const ownerName = session.user.name ?? "there";
 
   const starterSuggestions = hasDescription
     ? [
@@ -100,13 +104,13 @@ async function handleCreateWorkspace(deps: ServerDependencies, request: Request)
 
   const starterMessage = hasDescription
     ? [
-        `Hey ${parsed.data.ownerDisplayName}!`,
+        `Hey ${ownerName}!`,
         `Got it — I'll help you organize ${parsed.data.name}.`,
         "What are the main projects or product areas you want to track?",
         "You can also drop in a document (plan, spec, PRD) and I'll extract everything from it.",
       ].join(" ")
     : [
-        `Hey ${parsed.data.ownerDisplayName}!`,
+        `Hey ${ownerName}!`,
         "I'm ready to help you build out your workspace.",
         "Tell me about what you're working on - what's the main project or business you want to track here?",
         "If you have an existing document (like a plan or spec), you can drop it in and I'll extract everything from it.",
@@ -122,19 +126,6 @@ async function handleCreateWorkspace(deps: ServerDependencies, request: Request)
       onboarding_turn_count: 0,
       onboarding_summary_pending: false,
       onboarding_started_at: now,
-      created_at: now,
-      updated_at: now,
-    });
-
-    const ownerEmbedding = await createEmbeddingVector(
-      deps.embeddingModel,
-      parsed.data.ownerDisplayName,
-      deps.config.embeddingDimension,
-    );
-    await transaction.create(ownerRecord).content({
-      name: parsed.data.ownerDisplayName,
-      contact_email: parsed.data.ownerEmail,
-      ...(ownerEmbedding ? { embedding: ownerEmbedding } : {}),
       created_at: now,
       updated_at: now,
     });

--- a/app/src/shared/contracts.ts
+++ b/app/src/shared/contracts.ts
@@ -10,8 +10,6 @@ export type EntityPriority = (typeof ENTITY_PRIORITIES)[number];
 
 export type CreateWorkspaceRequest = {
   name: string;
-  ownerDisplayName: string;
-  ownerEmail: string;
   description?: string;
 };
 

--- a/tests/smoke/conversation-sidebar.test.ts
+++ b/tests/smoke/conversation-sidebar.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type ChatMessageResponse = {
   messageId: string;
@@ -49,10 +49,11 @@ async function sendMessageAndWait(
   workspaceId: string,
   conversationId: string | undefined,
   text: string,
+  headers?: Record<string, string>,
 ): Promise<ChatMessageResponse> {
   const chatResponse = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify({
       clientMessageId: randomUUID(),
       workspaceId,
@@ -68,16 +69,16 @@ async function sendMessageAndWait(
 describe("conversation sidebar smoke", () => {
   it("returns sidebar in bootstrap and via dedicated endpoint", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "sidebar-1");
 
     // Create workspace
     const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(
       `${baseUrl}/api/workspaces`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...user.headers },
         body: JSON.stringify({
           name: `Sidebar Smoke ${Date.now()}`,
-          ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-1@smoke.test`,
         }),
       },
     );
@@ -88,6 +89,7 @@ describe("conversation sidebar smoke", () => {
       workspace.workspaceId,
       workspace.conversationId,
       "Task: implement the authentication module for the Brain platform. Decision: use JWT tokens for session management. Feature: user authentication with OAuth2 support.",
+      user.headers,
     );
 
     // Check sidebar endpoint
@@ -114,16 +116,16 @@ describe("conversation sidebar smoke", () => {
 
   it("creates a new conversation when conversationId is omitted", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "sidebar-2");
 
     // Create workspace
     const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(
       `${baseUrl}/api/workspaces`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...user.headers },
         body: JSON.stringify({
           name: `NewConv Smoke ${Date.now()}`,
-          ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-2@smoke.test`,
         }),
       },
     );
@@ -134,6 +136,7 @@ describe("conversation sidebar smoke", () => {
       workspace.workspaceId,
       undefined,
       "New conversation about the deployment pipeline",
+      user.headers,
     );
 
     expect(chatResponse.conversationId).toBeDefined();
@@ -150,15 +153,15 @@ describe("conversation sidebar smoke", () => {
 
   it("conversation endpoint returns messages for existing conversation", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "sidebar-3");
 
     const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(
       `${baseUrl}/api/workspaces`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...user.headers },
         body: JSON.stringify({
           name: `ConvLoad Smoke ${Date.now()}`,
-          ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-3@smoke.test`,
         }),
       },
     );
@@ -169,6 +172,7 @@ describe("conversation sidebar smoke", () => {
       workspace.workspaceId,
       workspace.conversationId,
       "Testing conversation loading",
+      user.headers,
     );
 
     // Load the conversation via dedicated endpoint

--- a/tests/smoke/extraction-quality.test.ts
+++ b/tests/smoke/extraction-quality.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { RecordId, Surreal } from "surrealdb";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type AssistantMessageEvent = {
   type: "assistant_message";
@@ -28,13 +28,13 @@ const getRuntime = setupSmokeSuite("extraction_quality");
 describe("extraction quality smoke", () => {
   it("filters placeholders and avoids unresolved person node creation", async () => {
     const { baseUrl, surreal } = getRuntime();
+    const user = await createTestUser(baseUrl, "extraction");
 
     const create = await fetchJson<{ workspaceId: string; conversationId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: `Extraction Quality Smoke ${Date.now()}`,
-        ownerDisplayName: "Marcus Stone", ownerEmail: `${Date.now()}-1@smoke.test`,
       }),
     });
 
@@ -47,6 +47,7 @@ describe("extraction quality smoke", () => {
       workspaceId: create.workspaceId,
       conversationId: create.conversationId,
       text: "I'll describe my project",
+      headers: user.headers,
     });
 
     const placeholderExtraction = placeholderEvents.find((event) => event.type === "extraction");
@@ -68,6 +69,7 @@ describe("extraction quality smoke", () => {
       workspaceId: create.workspaceId,
       conversationId: create.conversationId,
       text: "Person: Sarah. Decision: Use TypeScript for backend implementation.",
+      headers: user.headers,
     });
     expect(unknownPersonEvents.some((event) => event.type === "assistant_message")).toBe(true);
 
@@ -80,6 +82,7 @@ describe("extraction quality smoke", () => {
       workspaceId: create.workspaceId,
       conversationId: create.conversationId,
       text: "Marcus decided to use SurrealDB for graph persistence.",
+      headers: user.headers,
     });
 
     const assistantEvent = knownPersonEvents.find((event) => event.type === "assistant_message");
@@ -134,11 +137,12 @@ async function sendChatAndCollectEvents(
     workspaceId: string;
     conversationId: string;
     text: string;
+    headers?: Record<string, string>;
   },
 ): Promise<StreamEvent[]> {
   const message = await fetchJson<{ streamUrl: string }>(`${baseUrl}/api/chat/messages`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...input.headers },
     body: JSON.stringify({
       clientMessageId: randomUUID(),
       workspaceId: input.workspaceId,

--- a/tests/smoke/github-webhook.test.ts
+++ b/tests/smoke/github-webhook.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { RecordId } from "surrealdb";
-import { fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 const getRuntime = setupSmokeSuite("github-webhook");
 
@@ -46,11 +46,12 @@ async function pollForRecord<T>(
 describe("github webhook smoke", () => {
   it("rejects request without x-github-event header", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "webhook-1");
 
     const workspace = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}`, ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-1@smoke.test` }),
+      headers: { "Content-Type": "application/json", ...user.headers },
+      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}` }),
     });
 
     const res = await fetch(`${baseUrl}/api/workspaces/${workspace.workspaceId}/webhooks/github`, {
@@ -64,11 +65,12 @@ describe("github webhook smoke", () => {
 
   it("returns 200 for non-push events", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "webhook-2");
 
     const workspace = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}`, ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-2@smoke.test` }),
+      headers: { "Content-Type": "application/json", ...user.headers },
+      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}` }),
     });
 
     const res = await fetch(`${baseUrl}/api/workspaces/${workspace.workspaceId}/webhooks/github`, {
@@ -88,11 +90,12 @@ describe("github webhook smoke", () => {
 
   it("accepts pushes on non-default branches", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "webhook-3");
 
     const workspace = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}`, ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-3@smoke.test` }),
+      headers: { "Content-Type": "application/json", ...user.headers },
+      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}` }),
     });
 
     const event = makePushEvent({ ref: "refs/heads/feature-branch", defaultBranch: "main" });
@@ -113,11 +116,12 @@ describe("github webhook smoke", () => {
 
   it("returns 200 for non-branch refs", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "webhook-4");
 
     const workspace = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}`, ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-4@smoke.test` }),
+      headers: { "Content-Type": "application/json", ...user.headers },
+      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}` }),
     });
 
     const event = makePushEvent({ ref: "refs/tags/v1.2.3", defaultBranch: "main" });
@@ -138,11 +142,12 @@ describe("github webhook smoke", () => {
 
   it("accepts push to default branch and creates git_commit with extraction", async () => {
     const { baseUrl, surreal } = getRuntime();
+    const user = await createTestUser(baseUrl, "webhook-5");
 
     const workspace = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}`, ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-5@smoke.test` }),
+      headers: { "Content-Type": "application/json", ...user.headers },
+      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}` }),
     });
 
     const sha = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
@@ -214,11 +219,12 @@ describe("github webhook smoke", () => {
 
   it("links commit to explicit task ids from commit message", async () => {
     const { baseUrl, surreal } = getRuntime();
+    const user = await createTestUser(baseUrl, "webhook-6");
 
     const workspace = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}`, ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-6@smoke.test` }),
+      headers: { "Content-Type": "application/json", ...user.headers },
+      body: JSON.stringify({ name: `Webhook Smoke ${Date.now()}` }),
     });
 
     const workspaceRecord = new RecordId("workspace", workspace.workspaceId);

--- a/tests/smoke/intent-context.test.ts
+++ b/tests/smoke/intent-context.test.ts
@@ -4,7 +4,7 @@ import { RecordId, type Surreal } from "surrealdb";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { generateApiKey, hashApiKey } from "../../app/src/server/mcp/api-key";
 import { createEmbeddingVector } from "../../app/src/server/graph/embeddings";
-import { fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -36,12 +36,12 @@ async function createWorkspaceWithApiKey(
   surreal: Surreal,
   name?: string,
 ): Promise<AuthedWorkspace> {
+  const user = await createTestUser(baseUrl, "intent");
   const { workspaceId } = await fetchJson<{ workspaceId: string }>(`${baseUrl}/api/workspaces`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...user.headers },
     body: JSON.stringify({
       name: name ?? `Intent Smoke ${Date.now()}`,
-      ownerDisplayName: "Test", ownerEmail: `${Date.now()}-1@smoke.test`,
     }),
   });
 

--- a/tests/smoke/onboarding.test.ts
+++ b/tests/smoke/onboarding.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type ChatMessageResponse = {
   messageId: string;
@@ -24,6 +24,7 @@ const getRuntime = setupSmokeSuite("onboarding");
 describe("onboarding smoke", () => {
   it("bootstraps onboarding and completes full onboarding flow", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "onboarding");
 
     const create = await fetchJson<{
       workspaceId: string;
@@ -32,10 +33,9 @@ describe("onboarding smoke", () => {
       onboardingComplete: boolean;
     }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: `Smoke Workspace ${Date.now()}`,
-        ownerDisplayName: "Smoke Owner", ownerEmail: `${Date.now()}-1@smoke.test`,
       }),
     });
 
@@ -56,7 +56,7 @@ describe("onboarding smoke", () => {
 
     const firstChat = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: create.workspaceId,
@@ -93,6 +93,7 @@ describe("onboarding smoke", () => {
 
     const uploadResponse = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
+      headers: { ...user.headers },
       body: uploadForm,
     });
 
@@ -102,7 +103,7 @@ describe("onboarding smoke", () => {
 
     const confirm = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: create.workspaceId,

--- a/tests/smoke/phase1.test.ts
+++ b/tests/smoke/phase1.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type ChatMessageResponse = {
   messageId: string;
@@ -32,18 +32,19 @@ describe("phase1 smoke", () => {
     const health = await fetchJson<{ status: string }>(`${baseUrl}/healthz`);
     expect(health.status).toBe("ok");
 
+    const user = await createTestUser(baseUrl, "phase1");
+
     const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: `Phase1 Smoke ${Date.now()}`,
-        ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-1@smoke.test`,
       }),
     });
 
     const chatResponse = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: workspace.workspaceId,

--- a/tests/smoke/pipeline.test.ts
+++ b/tests/smoke/pipeline.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { RecordId, type Surreal } from "surrealdb";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, type TestUser, setupSmokeSuite } from "./smoke-test-kit";
 
 type ChatMessageResponse = {
   messageId: string;
@@ -27,13 +27,13 @@ const getRuntime = setupSmokeSuite("pipeline");
 async function createOnboardedWorkspace(
   baseUrl: string,
   surreal: Surreal,
+  user: TestUser,
 ): Promise<{ workspaceId: string; conversationId: string }> {
   const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(`${baseUrl}/api/workspaces`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...user.headers },
     body: JSON.stringify({
       name: `Pipeline Smoke ${Date.now()}`,
-      ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-1@smoke.test`,
     }),
   });
 
@@ -51,11 +51,12 @@ async function createOnboardedWorkspace(
 describe("agent-controlled extraction smoke", () => {
   it("chat agent handles decision language", async () => {
     const { baseUrl, surreal } = getRuntime();
-    const workspace = await createOnboardedWorkspace(baseUrl, surreal);
+    const user = await createTestUser(baseUrl, "pipeline-1");
+    const workspace = await createOnboardedWorkspace(baseUrl, surreal, user);
 
     const message = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: workspace.workspaceId,
@@ -107,11 +108,12 @@ describe("agent-controlled extraction smoke", () => {
 
   it("no entities created for casual conversation", async () => {
     const { baseUrl, surreal } = getRuntime();
-    const workspace = await createOnboardedWorkspace(baseUrl, surreal);
+    const user = await createTestUser(baseUrl, "pipeline-2");
+    const workspace = await createOnboardedWorkspace(baseUrl, surreal, user);
 
     const message = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: workspace.workspaceId,
@@ -132,7 +134,8 @@ describe("agent-controlled extraction smoke", () => {
 
   it("PM agent creates task from explicit request", async () => {
     const { baseUrl, surreal } = getRuntime();
-    const workspace = await createOnboardedWorkspace(baseUrl, surreal);
+    const user = await createTestUser(baseUrl, "pipeline-3");
+    const workspace = await createOnboardedWorkspace(baseUrl, surreal, user);
 
     // Seed a project so the PM agent has something to scope tasks under
     const projectRecord = new RecordId("project", randomUUID());
@@ -152,7 +155,7 @@ describe("agent-controlled extraction smoke", () => {
 
     const message = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: workspace.workspaceId,

--- a/tests/smoke/priority.test.ts
+++ b/tests/smoke/priority.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { RecordId } from "surrealdb";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { type TestUser, collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type ChatMessageResponse = {
   messageId: string;
@@ -23,13 +23,13 @@ const getRuntime = setupSmokeSuite("priority");
 async function createOnboardedWorkspace(
   baseUrl: string,
   surreal: import("surrealdb").Surreal,
+  user: TestUser,
 ): Promise<{ workspaceId: string; conversationId: string }> {
   const workspace = await fetchJson<{ workspaceId: string; conversationId: string }>(`${baseUrl}/api/workspaces`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...user.headers },
     body: JSON.stringify({
       name: `Priority Smoke ${Date.now()}`,
-      ownerDisplayName: "Marcus", ownerEmail: `${Date.now()}-1@smoke.test`,
     }),
   });
 
@@ -45,11 +45,12 @@ async function createOnboardedWorkspace(
 describe("priority extraction smoke", () => {
   it("chat agent handles urgent task message and responds meaningfully", async () => {
     const { baseUrl, surreal } = getRuntime();
-    const workspace = await createOnboardedWorkspace(baseUrl, surreal);
+    const user = await createTestUser(baseUrl, "priority-urgent");
+    const workspace = await createOnboardedWorkspace(baseUrl, surreal, user);
 
     const message = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: workspace.workspaceId,
@@ -92,11 +93,12 @@ describe("priority extraction smoke", () => {
 
   it("chat agent handles low-priority deferred language", async () => {
     const { baseUrl, surreal } = getRuntime();
-    const workspace = await createOnboardedWorkspace(baseUrl, surreal);
+    const user = await createTestUser(baseUrl, "priority-low");
+    const workspace = await createOnboardedWorkspace(baseUrl, surreal, user);
 
     const message = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: workspace.workspaceId,

--- a/tests/smoke/readme-import.test.ts
+++ b/tests/smoke/readme-import.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { RecordId } from "surrealdb";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type StreamEvent =
   | { type: "assistant_message"; messageId: string; text: string }
@@ -14,16 +14,16 @@ const getRuntime = setupSmokeSuite("readme_import");
 describe("README import smoke", () => {
   it("ingests README.md and persists document chunks", async () => {
     const { baseUrl, surreal } = getRuntime();
+    const user = await createTestUser(baseUrl, "readme");
 
     const readmeText = await Bun.file(new URL("../../README.md", import.meta.url)).text();
     expect(readmeText.trim().length).toBeGreaterThan(0);
 
     const create = await fetchJson<{ workspaceId: string; conversationId: string }>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: `README Smoke ${Date.now()}`,
-        ownerDisplayName: "README Smoke Owner", ownerEmail: `${Date.now()}-1@smoke.test`,
       }),
     });
 
@@ -38,6 +38,7 @@ describe("README import smoke", () => {
 
     const uploadResponse = await fetchJson<{ streamUrl: string }>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
+      headers: { ...user.headers },
       body: uploadForm,
     });
 

--- a/tests/smoke/smoke-test-kit.ts
+++ b/tests/smoke/smoke-test-kit.ts
@@ -114,6 +114,33 @@ export function setupSmokeSuite(suiteName: string): () => SmokeTestRuntime {
   };
 }
 
+export type TestUser = {
+  headers: Record<string, string>;
+};
+
+export async function createTestUser(baseUrl: string, suffix: string): Promise<TestUser> {
+  const email = `smoke-${Date.now()}-${suffix}@test.local`;
+  const response = await fetch(`${baseUrl}/api/auth/sign-up/email`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name: "Smoke Tester", email, password: "smoke-test-password-123" }),
+    redirect: "manual",
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to create test user (${response.status}): ${body}`);
+  }
+
+  const setCookie = response.headers.getSetCookie();
+  if (!setCookie || setCookie.length === 0) {
+    throw new Error("Sign-up did not return session cookies");
+  }
+
+  const cookieHeader = setCookie.map((c) => c.split(";")[0]).join("; ");
+  return { headers: { Cookie: cookieHeader } };
+}
+
 export async function collectSseEvents<T extends { type: string }>(streamUrl: string, timeoutMs: number): Promise<T[]> {
   const response = await fetch(streamUrl, { headers: { Accept: "text/event-stream" } });
   if (!response.ok || !response.body) {

--- a/tests/smoke/workspace-description.test.ts
+++ b/tests/smoke/workspace-description.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { randomUUID } from "node:crypto";
 import { RecordId } from "surrealdb";
-import { collectSseEvents, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
+import { collectSseEvents, createTestUser, fetchJson, setupSmokeSuite } from "./smoke-test-kit";
 
 type CreateWorkspaceResponse = {
   workspaceId: string;
@@ -40,37 +40,16 @@ type StreamEvent =
 
 const getRuntime = setupSmokeSuite("workspace_description");
 
-function testEmail(label: string): string {
-  return `${label}-${Date.now()}@smoke.test`;
-}
-
-async function signUp(baseUrl: string, email: string, name: string): Promise<Record<string, string>> {
-  const res = await fetch(`${baseUrl}/api/auth/sign-up/email`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, password: "smoke-test-password-123!", name }),
-  });
-  if (!res.ok) throw new Error(`Sign up failed: ${res.status} ${await res.text()}`);
-  const data = (await res.json()) as { token: string };
-  const cookies = res.headers.getSetCookie();
-  const sessionCookie = cookies.find((c) => c.startsWith("better-auth.session_token="));
-  const sessionToken = sessionCookie
-    ? decodeURIComponent(sessionCookie.split("=")[1].split(";")[0])
-    : data.token;
-  return { Cookie: `better-auth.session_token=${sessionToken}` };
-}
-
 describe("workspace description in onboarding", () => {
   it("creates workspace with description and adapts starter message", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "desc");
 
     const create = await fetchJson<CreateWorkspaceResponse>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: "DabDash",
-        ownerDisplayName: "Marcus",
-        ownerEmail: testEmail("desc"),
         description: "Cannabis delivery storefront platform",
       }),
     });
@@ -104,18 +83,13 @@ describe("workspace description in onboarding", () => {
 
   it("creates workspace without description and does not create a project entity", async () => {
     const { baseUrl, surreal } = getRuntime();
-
-    // Sign up first to get session cookies for chat endpoint
-    const authEmail = testEmail("nodesc-auth");
-    const authHeaders = await signUp(baseUrl, authEmail, "Tester");
+    const user = await createTestUser(baseUrl, "nodesc");
 
     const create = await fetchJson<CreateWorkspaceResponse>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: "TestCorp",
-        ownerDisplayName: "Tester",
-        ownerEmail: testEmail("nodesc"),
       }),
     });
 
@@ -141,7 +115,7 @@ describe("workspace description in onboarding", () => {
     // Send a message describing the business (not a specific project)
     const chatResponse = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", ...authHeaders },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: create.workspaceId,
@@ -166,19 +140,14 @@ describe("workspace description in onboarding", () => {
 
   it("workspace with description streams a chat response successfully", async () => {
     const { baseUrl } = getRuntime();
-
-    // Sign up first to get session cookies for chat endpoint
-    const authEmail = testEmail("flow-auth");
-    const authHeaders = await signUp(baseUrl, authEmail, "Marcus");
+    const user = await createTestUser(baseUrl, "flow");
 
     // Create workspace with description
     const create = await fetchJson<CreateWorkspaceResponse>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: "DabDash",
-        ownerDisplayName: "Marcus",
-        ownerEmail: testEmail("flow"),
         description: "Cannabis delivery storefront platform",
       }),
     });
@@ -186,7 +155,7 @@ describe("workspace description in onboarding", () => {
     // Send first chat message describing a project
     const firstChat = await fetchJson<ChatMessageResponse>(`${baseUrl}/api/chat/messages`, {
       method: "POST",
-      headers: { "Content-Type": "application/json", ...authHeaders },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         clientMessageId: randomUUID(),
         workspaceId: create.workspaceId,
@@ -207,14 +176,13 @@ describe("workspace description in onboarding", () => {
 
   it("trims whitespace-only description to undefined", async () => {
     const { baseUrl } = getRuntime();
+    const user = await createTestUser(baseUrl, "empty");
 
     const create = await fetchJson<CreateWorkspaceResponse>(`${baseUrl}/api/workspaces`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...user.headers },
       body: JSON.stringify({
         name: "EmptyDesc",
-        ownerDisplayName: "Tester",
-        ownerEmail: testEmail("empty"),
         description: "   ",
       }),
     });


### PR DESCRIPTION
## Summary

Logged-in users are now automatically set as workspace owners during creation. The workspace creation endpoint no longer requires owner details in the request—it retrieves the authenticated user's session and creates a member_of relationship linking their existing person record to the new workspace.

## Changes

- Remove `ownerDisplayName` and `ownerEmail` from `CreateWorkspaceRequest` contract
- Update workspace creation handler to extract authenticated user via `deps.auth.api.getSession()`
- Create `member_of` edge between user's person record and workspace (instead of creating new person)
- Simplify workspace creation form to require only workspace name (and optional description)
- Add `createTestUser()` helper to smoke test kit for session-based authentication
- Update all 10 smoke tests to authenticate before workspace creation and pass auth cookies to API calls

## Motivation

User details are now available at login time, making them unnecessary as form inputs during workspace creation. This simplifies onboarding and ensures the workspace owner is always the authenticated user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)