### PR TITLE
Add Traces and Policies to marketing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Agent Layer
 Graph Layer
   → Projects / Decisions / Tasks / Observations / Features / Questions
   → Suggestions / Conversations / Commits / Intents / Learnings
+  → Traces / Policies
 
 Auth Layer
   → OAuth 2.1 / RAR (RFC 9396) / DPoP (RFC 9449) / Better Auth IdP
@@ -51,7 +52,7 @@ Integration Layer
 | Autonomy | "Let it rip" (high risk of loops) | Authority scopes (risk-managed) |
 | Over time | Performance degrades | System gets smarter via learnings |
 | Security | Sandbox isolation (the "box") | Governance graph + sandbox (the "brain") |
-| Auditing | Log-based (text dumps) | Graph-based (structured, machine-readable) |
+| Auditing | Log-based (text dumps) | Graph-based (hierarchical traces, machine-readable) |
 
 ## Specialized Agents
 
@@ -87,6 +88,8 @@ No agent messages another agent. They write structured signals to the knowledge 
 - **Learnings** — Behavioral rules injected into agent prompts at runtime. The system gets smarter as it works, not dumber.
 - **Identity** — One person across all tools. Your Slack, GitHub, and terminal sessions all resolve to the same identity.
 - **Agent Sessions** — Every session is remembered. The next agent knows what the last one did.
+- **Traces** — Every agent execution is a graph-native call tree. Subagent spawns, tool calls, and decisions form a hierarchical trace you can traverse, query, and audit. Forensic debugging is a graph query, not grep.
+- **Policies** — Deterministic governance rules stored as graph nodes, not prompt text. Each policy carries typed rules, scopes, and approval requirements. The Authorizer evaluates intents against the policy graph before minting tokens — no prompt rewriting needed.
 
 ## Reliability: Solving the Three Drifts
 
@@ -102,6 +105,8 @@ Most autonomous platforms are black boxes. Brain is a signed logic trace. Every 
 
 - **Governance telemetry** — Every decision is a node with a UUID, author, timestamp, and reasoning. Auditors can query the graph directly.
 - **Signed intent chains** — When an agent spends money or merges code, the graph records which intent authorized it, which authority scope permitted it, and which human approved it.
+- **Hierarchical traces** — Agent executions are graph-native call trees. A subagent spawn becomes a root trace; each tool call, message, and decision is a child node. Traverse the full execution path with a graph query — from intent to final action.
+- **Policy-as-graph** — Governance rules are structured nodes with typed rules, scopes, and approval requirements. The Authorizer evaluates intents against the policy graph before minting tokens — deterministic, auditable, and updateable without touching a single prompt.
 - **The "Judge" pattern** — High-stakes actions go through an Authorizer Agent that validates intents against policy constraints before minting scoped tokens. The worker never sees master keys.
 
 ## Open Source

--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@ footer .right a:hover { color: var(--text-dim); }
     <div class="d-arrow">↕</div>
     <div class="d-row"><div class="d-tag">Agents</div><div class="d-boxes"><div class="d-box a">Architect</div><div class="d-box a">Strategist</div><div class="d-box a">Management</div><div class="d-box a">Coding · MCP</div><div class="d-box a">Observer</div></div></div>
     <div class="d-arrow">↕</div>
-    <div class="d-row"><div class="d-tag">Graph</div><div class="d-boxes"><div class="d-box g">Projects</div><div class="d-box g">Decisions</div><div class="d-box g">Tasks</div><div class="d-box g">Observations</div><div class="d-box g">Features</div><div class="d-box g">Questions</div><div class="d-box g">Suggestions</div><div class="d-box g">Conversations</div><div class="d-box g">Commits</div><div class="d-box g">Intents</div><div class="d-box g">Learnings</div></div></div>
+    <div class="d-row"><div class="d-tag">Graph</div><div class="d-boxes"><div class="d-box g">Projects</div><div class="d-box g">Decisions</div><div class="d-box g">Tasks</div><div class="d-box g">Observations</div><div class="d-box g">Features</div><div class="d-box g">Questions</div><div class="d-box g">Suggestions</div><div class="d-box g">Conversations</div><div class="d-box g">Commits</div><div class="d-box g">Intents</div><div class="d-box g">Learnings</div><div class="d-box g">Traces</div><div class="d-box g">Policies</div></div></div>
     <div class="d-arrow">↕</div>
     <div class="d-row"><div class="d-tag">Auth</div><div class="d-boxes"><div class="d-box i">OAuth 2.1</div><div class="d-box i">RAR (RFC 9396)</div><div class="d-box i">DPoP (RFC 9449)</div><div class="d-box i">Better Auth IdP</div></div></div>
     <div class="d-arrow">↕</div>
@@ -426,7 +426,7 @@ footer .right a:hover { color: var(--text-dim); }
       <tr><td>Autonomy</td><td>"Let it rip" (high risk of loops)</td><td>Authority scopes (risk-managed)</td></tr>
       <tr><td>Over time</td><td>Performance degrades</td><td>System gets smarter via learnings</td></tr>
       <tr><td>Security</td><td>Sandbox isolation (the "box")</td><td>Governance graph + sandbox (the "brain")</td></tr>
-      <tr><td>Auditing</td><td>Log-based (text dumps)</td><td>Graph-based (structured, machine-readable)</td></tr>
+      <tr><td>Auditing</td><td>Log-based (text dumps)</td><td>Graph-based (hierarchical traces, machine-readable)</td></tr>
     </tbody>
   </table>
 </section>
@@ -605,6 +605,14 @@ footer .right a:hover { color: var(--text-dim); }
       <h3>⟐ Identity</h3>
       <p>One person across all tools. Your Slack, GitHub, and terminal sessions all resolve to the same identity. Agents act on your behalf with scoped permissions.</p>
     </div>
+    <div class="concept">
+      <h3>⟁ Traces</h3>
+      <p>Every agent execution is a graph-native call tree — not a log file. Subagent spawns, tool calls, and decisions form a hierarchical trace you can traverse, query, and audit. Forensic debugging is a graph query, not grep.</p>
+    </div>
+    <div class="concept">
+      <h3>⛊ Policies</h3>
+      <p>Deterministic governance rules stored as graph nodes, not prompt text. Agents evaluate intents against policy constraints before acting. Update one node to change what every agent is allowed to do — no prompt rewriting.</p>
+    </div>
   </div>
 </section>
 
@@ -691,6 +699,14 @@ footer .right a:hover { color: var(--text-dim); }
     <div class="concept">
       <h3>Signed intent chains</h3>
       <p>When an agent spends money or merges code, the graph records which intent authorized it, which authority scope permitted it, and which human (or consensus) approved it. The full chain is machine-readable.</p>
+    </div>
+    <div class="concept">
+      <h3>Hierarchical traces</h3>
+      <p>Agent executions are graph-native call trees. A subagent spawn becomes a root trace; each tool call, message, and decision is a child node. Traverse the full execution path with a graph query — from intent to final action.</p>
+    </div>
+    <div class="concept">
+      <h3>Policy-as-graph</h3>
+      <p>Governance rules are structured nodes, not prompt instructions. Each policy carries typed rules, scopes, and approval requirements. The Authorizer evaluates intents against the policy graph before minting tokens — deterministic, auditable, and updateable without touching a single prompt.</p>
     </div>
     <div class="concept">
       <h3>Eval-ready metrics</h3>


### PR DESCRIPTION
## Summary

Added comprehensive documentation for Traces and Policies — two critical primitives in Brain's graph-native architecture for forensic debugging and deterministic governance.

## Changes

- **Architecture diagram**: Added Traces and Policies to the Graph Layer in both index.html and README.md
- **Key Concepts cards**: Two new concept cards explaining hierarchical traces (graph-native call trees) and policy-as-graph (deterministic governance rules as structured nodes)
- **Verifiable Autonomy section**: Enhanced with specific details on how traces enable graph-queryable execution paths and policies enable auditable authorization evaluation
- **Comparison table**: Updated the Auditing row to reference "hierarchical traces" instead of generic "structured, machine-readable"
- **Synchronized docs**: Both index.html landing page and README.md now have aligned messaging about traces and policies

This aligns the marketing documentation with the recent implementation of the trace table (migration 0023) and policy infrastructure for intent authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)