### PR TITLE
refactor: deduplicate shared test utility helpers across acceptance test kits

### DIFF
--- a/tests/acceptance/agent-learnings/learning-test-kit.ts
+++ b/tests/acceptance/agent-learnings/learning-test-kit.ts
@@ -12,6 +12,11 @@
  */
 import { RecordId, type Surreal } from "surrealdb";
 import { embedMany } from "ai";
+import {
+  createWorkspaceDirectly,
+  createDecisionDirectly,
+  type DirectWorkspaceResult,
+} from "../shared-fixtures";
 
 // ---------------------------------------------------------------------------
 // Re-exports from shared kit
@@ -118,41 +123,10 @@ export async function createTestWorkspace(
   surreal: Surreal,
   suffix: string,
 ): Promise<{ workspaceId: string; identityId: string }> {
-  const workspaceId = `ws-${crypto.randomUUID()}`;
-  const identityId = `id-${crypto.randomUUID()}`;
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-  const identityRecord = new RecordId("identity", identityId);
-
-  await surreal.query(`CREATE $workspace CONTENT $content;`, {
-    workspace: workspaceRecord,
-    content: {
-      name: `Learning Test Workspace ${suffix}`,
-      status: "active",
-      onboarding_complete: true,
-      onboarding_turn_count: 0,
-      onboarding_summary_pending: false,
-      onboarding_started_at: new Date(),
-      created_at: new Date(),
-    },
+  const result = await createWorkspaceDirectly(surreal, suffix, {
+    workspaceName: `Learning Test Workspace ${suffix}`,
   });
-
-  await surreal.query(`CREATE $identity CONTENT $content;`, {
-    identity: identityRecord,
-    content: {
-      name: `Test User ${suffix}`,
-      type: "human",
-      identity_status: "active",
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
-  });
-
-  await surreal.query(
-    `RELATE $identity->member_of->$workspace SET added_at = time::now();`,
-    { identity: identityRecord, workspace: workspaceRecord },
-  );
-
-  return { workspaceId, identityId };
+  return { workspaceId: result.workspaceId, identityId: result.identityId };
 }
 
 /**
@@ -322,24 +296,13 @@ export async function createTestDecision(
     embedding: number[];
   }> = {},
 ): Promise<{ decisionId: string }> {
-  const decisionId = `decision-${crypto.randomUUID()}`;
-  const decisionRecord = new RecordId("decision", decisionId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  await surreal.query(`CREATE $dec CONTENT $content;`, {
-    dec: decisionRecord,
-    content: {
-      summary: overrides.summary ?? "Test decision for collision detection",
-      rationale: overrides.rationale ?? "Decided for testing purposes",
-      status: overrides.status ?? "confirmed",
-      workspace: workspaceRecord,
-      created_at: new Date(),
-      updated_at: new Date(),
-      ...(overrides.embedding ? { embedding: overrides.embedding } : {}),
-    },
+  const result = await createDecisionDirectly(surreal, workspaceId, {
+    summary: overrides.summary ?? "Test decision for collision detection",
+    rationale: overrides.rationale ?? "Decided for testing purposes",
+    status: overrides.status,
+    embedding: overrides.embedding,
   });
-
-  return { decisionId };
+  return { decisionId: result.decisionId };
 }
 
 /**

--- a/tests/acceptance/intent-node/intent-test-kit.ts
+++ b/tests/acceptance/intent-node/intent-test-kit.ts
@@ -10,6 +10,11 @@
  *   MCP tools: create_intent, submit_intent, get_intent_status
  */
 import { RecordId, type Surreal } from "surrealdb";
+import {
+  createIntentDirectly,
+  createIdentity,
+  type ActionSpec,
+} from "../shared-fixtures";
 
 // Re-export everything from orchestrator-test-kit
 export {
@@ -35,6 +40,9 @@ import {
   type TestUserWithToken,
 } from "../coding-agent-orchestrator/orchestrator-test-kit";
 
+// Re-export ActionSpec from shared-fixtures (single source of truth)
+export type { ActionSpec } from "../shared-fixtures";
+
 // ---------------------------------------------------------------------------
 // Intent-Specific Types
 // ---------------------------------------------------------------------------
@@ -48,12 +56,6 @@ export type IntentStatus =
   | "completed"
   | "vetoed"
   | "failed";
-
-export type ActionSpec = {
-  provider: string;
-  action: string;
-  params?: Record<string, unknown>;
-};
 
 export type BudgetLimit = {
   amount: number;
@@ -109,55 +111,16 @@ export async function createDraftIntent(
   requesterId: string,
   opts: CreateIntentOptions,
 ): Promise<{ intentId: string; intentRecord: RecordId<"intent"> }> {
-  const intentId = `intent-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
-  const intentRecord = new RecordId("intent", intentId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-  const requesterRecord = new RecordId("identity", requesterId);
-
-  // Create trace record for the intent
-  const traceId = `trace-${intentId}`;
-  const traceRecord = new RecordId("trace", traceId);
-  await surreal.query(`CREATE $trace CONTENT $content;`, {
-    trace: traceRecord,
-    content: {
-      type: "intent_submission",
-      actor: requesterRecord,
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
-  });
-
-  const content: Record<string, unknown> = {
+  const result = await createIntentDirectly(surreal, workspaceId, requesterId, {
     goal: opts.goal,
     reasoning: opts.reasoning,
     status: "draft",
-    priority: opts.priority ?? 50,
-    action_spec: opts.action_spec,
-    trace_id: traceRecord,
-    requester: requesterRecord,
-    workspace: workspaceRecord,
-    created_at: new Date(),
-  };
-
-  if (opts.budget_limit) {
-    content.budget_limit = opts.budget_limit;
-  }
-
-  await surreal.query(`CREATE $intent CONTENT $content;`, {
-    intent: intentRecord,
-    content,
+    priority: opts.priority,
+    actionSpec: opts.action_spec,
+    budgetLimit: opts.budget_limit,
+    taskId: opts.taskId,
   });
-
-  // Link to originating task if provided
-  if (opts.taskId) {
-    const taskRecord = new RecordId("task", opts.taskId);
-    await surreal.query(
-      `RELATE $intent->triggered_by->$task SET created_at = time::now();`,
-      { intent: intentRecord, task: taskRecord },
-    );
-  }
-
-  return { intentId, intentRecord };
+  return { intentId: result.intentId, intentRecord: result.intentRecord };
 }
 
 /**
@@ -418,22 +381,16 @@ export async function createTestIdentity(
   type: "human" | "agent" = "agent",
   workspaceId?: string,
 ): Promise<string> {
-  const identityId = `id-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
-  const identityRecord = new RecordId("identity", identityId);
-
-  const content: Record<string, unknown> = {
-    name,
-    type,
-    created_at: new Date(),
-  };
-
   if (workspaceId) {
-    content.workspace = new RecordId("workspace", workspaceId);
+    const result = await createIdentity(surreal, workspaceId, name, type);
+    return result.identityId;
   }
-
+  // Legacy: identity without workspace (no member_of edge)
+  const identityId = `id-${crypto.randomUUID()}`;
+  const identityRecord = new RecordId("identity", identityId);
   await surreal.query(`CREATE $identity CONTENT $content;`, {
     identity: identityRecord,
-    content,
+    content: { name, type, created_at: new Date() },
   });
   return identityId;
 }

--- a/tests/acceptance/objective-behavior/objective-behavior-test-kit.ts
+++ b/tests/acceptance/objective-behavior/objective-behavior-test-kit.ts
@@ -25,6 +25,14 @@ import {
   type TestUser,
   type TestUserWithMcp,
 } from "../acceptance-test-kit";
+import {
+  createWorkspaceDirectly,
+  createIdentity,
+  createIntentDirectly,
+  createDecisionDirectly,
+  queryWorkspaceObservations as sharedQueryWorkspaceObservations,
+  type ActionSpec,
+} from "../shared-fixtures";
 
 // ---------------------------------------------------------------------------
 // Re-exports
@@ -120,44 +128,11 @@ export async function setupObjectiveWorkspace(
   workspaceId: string;
   identityId: string;
 }> {
-  const workspaceId = `ws-${crypto.randomUUID()}`;
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
   const user = await createTestUser(baseUrl, suffix);
-
-  await surreal.query(`CREATE $workspace CONTENT $content;`, {
-    workspace: workspaceRecord,
-    content: {
-      name: `Objective Test Workspace ${suffix}`,
-      status: "active",
-      onboarding_complete: true,
-      onboarding_turn_count: 0,
-      onboarding_summary_pending: false,
-      onboarding_started_at: new Date(),
-      created_at: new Date(),
-    },
+  const ws = await createWorkspaceDirectly(surreal, suffix, {
+    workspaceName: `Objective Test Workspace ${suffix}`,
   });
-
-  const identityId = `id-${crypto.randomUUID()}`;
-  const identityRecord = new RecordId("identity", identityId);
-
-  await surreal.query(`CREATE $identity CONTENT $content;`, {
-    identity: identityRecord,
-    content: {
-      name: `Test User ${suffix}`,
-      type: "human",
-      identity_status: "active",
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
-  });
-
-  await surreal.query(`RELATE $identity->member_of->$workspace SET added_at = time::now();`, {
-    identity: identityRecord,
-    workspace: workspaceRecord,
-  });
-
-  return { user, workspaceId, identityId };
+  return { user, workspaceId: ws.workspaceId, identityId: ws.identityId };
 }
 
 /**
@@ -168,27 +143,8 @@ export async function createAgentIdentity(
   workspaceId: string,
   agentName: string,
 ): Promise<{ identityId: string }> {
-  const identityId = `id-${crypto.randomUUID()}`;
-  const identityRecord = new RecordId("identity", identityId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  await surreal.query(`CREATE $identity CONTENT $content;`, {
-    identity: identityRecord,
-    content: {
-      name: agentName,
-      type: "agent",
-      identity_status: "active",
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
-  });
-
-  await surreal.query(`RELATE $identity->member_of->$workspace SET added_at = time::now();`, {
-    identity: identityRecord,
-    workspace: workspaceRecord,
-  });
-
-  return { identityId };
+  const result = await createIdentity(surreal, workspaceId, agentName, "agent");
+  return { identityId: result.identityId };
 }
 
 /**
@@ -387,46 +343,18 @@ export async function createIntent(
     goal: string;
     reasoning?: string;
     status?: string;
-    action_spec?: { provider: string; action: string; params?: Record<string, unknown> };
+    action_spec?: ActionSpec;
     embedding?: number[];
   },
 ): Promise<{ intentId: string }> {
-  const intentId = `intent-${crypto.randomUUID()}`;
-  const intentRecord = new RecordId("intent", intentId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-  const requesterRecord = new RecordId("identity", requesterId);
-  const traceId = `trace-${intentId}`;
-  const traceRecord = new RecordId("trace", traceId);
-
-  await surreal.query(`CREATE $trace CONTENT $content;`, {
-    trace: traceRecord,
-    content: {
-      type: "intent_submission",
-      actor: requesterRecord,
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
-  });
-
-  const intentContent: Record<string, unknown> = {
+  const result = await createIntentDirectly(surreal, workspaceId, requesterId, {
     goal: opts.goal,
-    reasoning: opts.reasoning ?? "Test intent",
+    reasoning: opts.reasoning,
     status: opts.status ?? "pending_auth",
-    priority: 50,
-    action_spec: opts.action_spec ?? { provider: "test", action: "test", params: {} },
-    trace_id: traceRecord,
-    requester: requesterRecord,
-    workspace: workspaceRecord,
-    created_at: new Date(),
-  };
-  if (opts.embedding !== undefined) intentContent.embedding = opts.embedding;
-
-  await surreal.query(`CREATE $intent CONTENT $content;`, {
-    intent: intentRecord,
-    content: intentContent,
+    actionSpec: opts.action_spec,
+    embedding: opts.embedding,
   });
-
-  return { intentId };
+  return { intentId: result.intentId };
 }
 
 /**
@@ -522,23 +450,12 @@ export async function createDecision(
     created_at?: Date;
   },
 ): Promise<{ decisionId: string }> {
-  const decisionId = `decision-${crypto.randomUUID()}`;
-  const decisionRecord = new RecordId("decision", decisionId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  await surreal.query(`CREATE $dec CONTENT $content;`, {
-    dec: decisionRecord,
-    content: {
-      summary: opts.summary,
-      rationale: "Test decision",
-      status: opts.status ?? "confirmed",
-      workspace: workspaceRecord,
-      created_at: opts.created_at ?? new Date(),
-      updated_at: new Date(),
-    },
+  const result = await createDecisionDirectly(surreal, workspaceId, {
+    summary: opts.summary,
+    status: opts.status,
+    created_at: opts.created_at,
   });
-
-  return { decisionId };
+  return { decisionId: result.decisionId };
 }
 
 /**
@@ -799,33 +716,7 @@ export async function getWorkspaceObservations(
   status: string;
   source_agent: string;
 }>> {
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  if (opts?.sourceAgent) {
-    const rows = (await surreal.query(
-      `SELECT * FROM observation WHERE workspace = $ws AND source_agent = $agent ORDER BY created_at DESC;`,
-      { ws: workspaceRecord, agent: opts.sourceAgent },
-    )) as Array<Array<{
-      id: RecordId;
-      text: string;
-      severity: string;
-      status: string;
-      source_agent: string;
-    }>>;
-    return rows[0] ?? [];
-  }
-
-  const rows = (await surreal.query(
-    `SELECT * FROM observation WHERE workspace = $ws ORDER BY created_at DESC;`,
-    { ws: workspaceRecord },
-  )) as Array<Array<{
-    id: RecordId;
-    text: string;
-    severity: string;
-    status: string;
-    source_agent: string;
-  }>>;
-  return rows[0] ?? [];
+  return sharedQueryWorkspaceObservations(surreal, workspaceId, opts?.sourceAgent);
 }
 
 /**

--- a/tests/acceptance/observer-agent/observer-test-kit.ts
+++ b/tests/acceptance/observer-agent/observer-test-kit.ts
@@ -9,6 +9,16 @@
  *   POST /api/observe/scan/:workspaceId  (periodic graph scan)
  */
 import { RecordId, type Surreal } from "surrealdb";
+import {
+  createIdentity,
+  createIntentDirectly,
+  createGitCommitDirectly,
+  createDecisionDirectly,
+  createObservationDirectly,
+  queryWorkspaceObservations as sharedQueryWorkspaceObservations,
+  type ActionSpec,
+  type ObservationSeverity as SharedObservationSeverity,
+} from "../shared-fixtures";
 
 // Re-export everything from orchestrator-test-kit
 export {
@@ -88,7 +98,7 @@ export type CreateGitCommitOptions = {
 export type CreateCompletedIntentOptions = {
   goal: string;
   reasoning: string;
-  actionSpec: { provider: string; action: string; params: Record<string, unknown> };
+  actionSpec: ActionSpec;
   status?: "completed" | "failed";
 };
 
@@ -228,31 +238,18 @@ export async function createTaskWithCommit(
   workspaceId: string,
   opts: CreateTaskWithCommitOptions,
 ): Promise<{ taskId: string; commitId: string; sha: string }> {
-  const taskId = `task-${crypto.randomUUID()}`;
-  const commitId = `commit-${crypto.randomUUID()}`;
   const sha = opts.sha ?? `abc${crypto.randomUUID().replace(/-/g, "").slice(0, 37)}`;
+
+  const { commitId, commitRecord } = await createGitCommitDirectly(surreal, workspaceId, sha, {
+    repository: opts.repository,
+    message: `feat: ${opts.title}`,
+    authorName: "test-agent",
+  });
+
+  const taskId = `task-${crypto.randomUUID()}`;
   const taskRecord = new RecordId("task", taskId);
-  const commitRecord = new RecordId("git_commit", commitId);
   const workspaceRecord = new RecordId("workspace", workspaceId);
 
-  // Create the git_commit record (but NOT via CREATE if we want to avoid triggering commit_created EVENT)
-  // Use a direct insert approach to seed without firing events
-  await surreal.query(
-    `CREATE $commit CONTENT $content;`,
-    {
-      commit: commitRecord,
-      content: {
-        sha,
-        repository: opts.repository ?? "org/repo",
-        message: `feat: ${opts.title}`,
-        author_name: "test-agent",
-        workspace: workspaceRecord,
-        created_at: new Date(),
-      },
-    },
-  );
-
-  // Create the task linked to the commit
   await surreal.query(
     `CREATE $task CONTENT $content;`,
     {
@@ -282,27 +279,8 @@ export async function createGitCommit(
   sha: string,
   opts?: CreateGitCommitOptions,
 ): Promise<{ commitId: string }> {
-  const commitId = `commit-${crypto.randomUUID()}`;
-  const commitRecord = new RecordId("git_commit", commitId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  await surreal.query(
-    `CREATE $commit CONTENT $content;`,
-    {
-      commit: commitRecord,
-      content: {
-        sha,
-        repository: opts?.repository ?? "org/repo",
-        message: opts?.message ?? "chore: test commit",
-        author_name: opts?.authorName ?? "test-agent",
-        url: opts?.url,
-        workspace: workspaceRecord,
-        created_at: new Date(),
-      },
-    },
-  );
-
-  return { commitId };
+  const result = await createGitCommitDirectly(surreal, workspaceId, sha, opts);
+  return { commitId: result.commitId };
 }
 
 /**
@@ -315,46 +293,20 @@ export async function createCompletedIntent(
   requesterId: string,
   opts: CreateCompletedIntentOptions,
 ): Promise<{ intentId: string }> {
-  const intentId = `intent-${crypto.randomUUID()}`;
-  const intentRecord = new RecordId("intent", intentId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-  const requesterRecord = new RecordId("identity", requesterId);
-  const traceId = `trace-${intentId}`;
-  const traceRecord = new RecordId("trace", traceId);
-
-  await surreal.query(`CREATE $trace CONTENT $content;`, {
-    trace: traceRecord,
-    content: {
-      type: "intent_submission",
-      actor: requesterRecord,
-      workspace: workspaceRecord,
-      created_at: new Date(),
+  const result = await createIntentDirectly(surreal, workspaceId, requesterId, {
+    goal: opts.goal,
+    reasoning: opts.reasoning,
+    status: opts.status ?? "completed",
+    actionSpec: opts.actionSpec,
+    evaluation: {
+      decision: "APPROVE",
+      risk_score: 10,
+      reason: "Pre-approved for testing",
+      evaluated_at: new Date(),
+      policy_only: false,
     },
   });
-
-  await surreal.query(`CREATE $intent CONTENT $content;`, {
-    intent: intentRecord,
-    content: {
-      goal: opts.goal,
-      reasoning: opts.reasoning,
-      status: opts.status ?? "completed",
-      priority: 50,
-      action_spec: opts.actionSpec,
-      trace_id: traceRecord,
-      requester: requesterRecord,
-      workspace: workspaceRecord,
-      evaluation: {
-        decision: "APPROVE",
-        risk_score: 10,
-        reason: "Pre-approved for testing",
-        evaluated_at: new Date(),
-        policy_only: false,
-      },
-      created_at: new Date(),
-    },
-  });
-
-  return { intentId };
+  return { intentId: result.intentId };
 }
 
 /**
@@ -373,33 +325,15 @@ export async function createObservationByAgent(
     targetId?: string;
   },
 ): Promise<{ observationId: string }> {
-  const observationId = `obs-${crypto.randomUUID()}`;
-  const observationRecord = new RecordId("observation", observationId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  await surreal.query(`CREATE $obs CONTENT $content;`, {
-    obs: observationRecord,
-    content: {
-      text: opts.text,
-      severity: opts.severity,
-      status: "open",
-      observation_type: opts.observationType,
-      source_agent: sourceAgent,
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
+  const result = await createObservationDirectly(surreal, workspaceId, {
+    text: opts.text,
+    severity: opts.severity,
+    observationType: opts.observationType,
+    sourceAgent,
+    targetTable: opts.targetTable,
+    targetId: opts.targetId,
   });
-
-  // Link observation to target entity if provided
-  if (opts.targetTable && opts.targetId) {
-    const targetRecord = new RecordId(opts.targetTable, opts.targetId);
-    await surreal.query(
-      `RELATE $obs->observes->$target SET added_at = time::now();`,
-      { obs: observationRecord, target: targetRecord },
-    );
-  }
-
-  return { observationId };
+  return { observationId: result.observationId };
 }
 
 /**
@@ -414,23 +348,12 @@ export async function createConfirmedDecision(
     status?: string;
   },
 ): Promise<{ decisionId: string }> {
-  const decisionId = `decision-${crypto.randomUUID()}`;
-  const decisionRecord = new RecordId("decision", decisionId);
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  await surreal.query(`CREATE $dec CONTENT $content;`, {
-    dec: decisionRecord,
-    content: {
-      summary: opts.summary,
-      rationale: opts.rationale ?? "Confirmed for testing",
-      status: opts.status ?? "confirmed",
-      workspace: workspaceRecord,
-      created_at: new Date(),
-      updated_at: new Date(),
-    },
+  const result = await createDecisionDirectly(surreal, workspaceId, {
+    summary: opts.summary,
+    rationale: opts.rationale ?? "Confirmed for testing",
+    status: opts.status,
   });
-
-  return { decisionId };
+  return { decisionId: result.decisionId };
 }
 
 /**
@@ -540,21 +463,7 @@ export async function getWorkspaceObservations(
   workspaceId: string,
   sourceAgent?: string,
 ): Promise<ObservationRecord[]> {
-  const workspaceRecord = new RecordId("workspace", workspaceId);
-
-  if (sourceAgent) {
-    const rows = (await surreal.query(
-      `SELECT * FROM observation WHERE workspace = $ws AND source_agent = $agent ORDER BY created_at DESC;`,
-      { ws: workspaceRecord, agent: sourceAgent },
-    )) as Array<ObservationRecord[]>;
-    return rows[0] ?? [];
-  }
-
-  const rows = (await surreal.query(
-    `SELECT * FROM observation WHERE workspace = $ws ORDER BY created_at DESC;`,
-    { ws: workspaceRecord },
-  )) as Array<ObservationRecord[]>;
-  return rows[0] ?? [];
+  return sharedQueryWorkspaceObservations(surreal, workspaceId, sourceAgent) as Promise<ObservationRecord[]>;
 }
 
 /**
@@ -629,20 +538,7 @@ export async function setupObserverWorkspace(
   const workspace = await createTestWorkspace(baseUrl, user);
 
   // Create an agent identity in this workspace
-  const identityId = `id-${crypto.randomUUID()}`;
-  const identityRecord = new RecordId("identity", identityId);
-  const workspaceRecord = new RecordId("workspace", workspace.workspaceId);
+  const result = await createIdentity(surreal, workspace.workspaceId, `Observer Test Agent ${suffix}`, "agent");
 
-  await surreal.query(`CREATE $identity CONTENT $content;`, {
-    identity: identityRecord,
-    content: {
-      name: `Observer Test Agent ${suffix}`,
-      type: "agent",
-      identity_status: "active",
-      workspace: workspaceRecord,
-      created_at: new Date(),
-    },
-  });
-
-  return { user, workspaceId: workspace.workspaceId, identityId };
+  return { user, workspaceId: workspace.workspaceId, identityId: result.identityId };
 }

--- a/tests/acceptance/shared-fixtures.ts
+++ b/tests/acceptance/shared-fixtures.ts
@@ -1,0 +1,397 @@
+/**
+ * Shared Test Fixtures — Canonical entity creation helpers
+ *
+ * Single source of truth for creating test entities in SurrealDB.
+ * Domain-specific test kits compose these helpers rather than reimplementing them.
+ *
+ * Types here mirror the SurrealDB schema with all required fields enforced
+ * at compile time, so schema changes only need updating in one place.
+ */
+import { RecordId, type Surreal } from "surrealdb";
+
+// ---------------------------------------------------------------------------
+// Shared Types — Schema-aligned, required fields enforced
+// ---------------------------------------------------------------------------
+
+export type ActionSpec = {
+  provider: string;
+  action: string;
+  params: Record<string, unknown>;
+};
+
+export type EvaluationResult = {
+  decision: "APPROVE" | "REJECT";
+  risk_score: number;
+  reason: string;
+  evaluated_at: Date;
+  policy_only: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Workspace + Identity (direct DB creation, no HTTP)
+// ---------------------------------------------------------------------------
+
+export type DirectWorkspaceResult = {
+  workspaceId: string;
+  workspaceRecord: RecordId<"workspace">;
+  identityId: string;
+  identityRecord: RecordId<"identity">;
+};
+
+/**
+ * Creates a workspace + identity + member_of edge directly in SurrealDB.
+ * Use when tests need an isolated workspace without going through HTTP signup.
+ */
+export async function createWorkspaceDirectly(
+  surreal: Surreal,
+  suffix: string,
+  opts?: {
+    workspaceName?: string;
+    identityName?: string;
+    identityType?: "human" | "agent";
+  },
+): Promise<DirectWorkspaceResult> {
+  const workspaceId = `ws-${crypto.randomUUID()}`;
+  const identityId = `id-${crypto.randomUUID()}`;
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+  const identityRecord = new RecordId("identity", identityId);
+
+  await surreal.query(
+    `CREATE $workspace CONTENT $content;`,
+    {
+      workspace: workspaceRecord,
+      content: {
+        name: opts?.workspaceName ?? `Test Workspace ${suffix}`,
+        status: "active",
+        onboarding_complete: true,
+        onboarding_turn_count: 0,
+        onboarding_summary_pending: false,
+        onboarding_started_at: new Date(),
+        created_at: new Date(),
+      },
+    },
+  );
+
+  await surreal.query(
+    `CREATE $identity CONTENT $content;`,
+    {
+      identity: identityRecord,
+      content: {
+        name: opts?.identityName ?? `Test User ${suffix}`,
+        type: opts?.identityType ?? "human",
+        identity_status: "active",
+        workspace: workspaceRecord,
+        created_at: new Date(),
+      },
+    },
+  );
+
+  await surreal.query(
+    `RELATE $identity->member_of->$workspace SET added_at = time::now();`,
+    { identity: identityRecord, workspace: workspaceRecord },
+  );
+
+  return { workspaceId, workspaceRecord, identityId, identityRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an identity record + member_of edge.
+ * Use when you already have a workspace and need an additional identity.
+ */
+export async function createIdentity(
+  surreal: Surreal,
+  workspaceId: string,
+  name: string,
+  type: "human" | "agent" = "agent",
+): Promise<{ identityId: string; identityRecord: RecordId<"identity"> }> {
+  const identityId = `id-${crypto.randomUUID()}`;
+  const identityRecord = new RecordId("identity", identityId);
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+
+  await surreal.query(
+    `CREATE $identity CONTENT $content;`,
+    {
+      identity: identityRecord,
+      content: {
+        name,
+        type,
+        identity_status: "active",
+        workspace: workspaceRecord,
+        created_at: new Date(),
+      },
+    },
+  );
+
+  await surreal.query(
+    `RELATE $identity->member_of->$workspace SET added_at = time::now();`,
+    { identity: identityRecord, workspace: workspaceRecord },
+  );
+
+  return { identityId, identityRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Intent
+// ---------------------------------------------------------------------------
+
+export type CreateIntentOpts = {
+  goal: string;
+  reasoning?: string;
+  status?: string;
+  priority?: number;
+  actionSpec?: ActionSpec;
+  embedding?: number[];
+  evaluation?: EvaluationResult;
+  budgetLimit?: { amount: number; currency: string };
+  taskId?: string;
+};
+
+/**
+ * Creates an intent + trace record directly in SurrealDB.
+ * Canonical helper — all intent creation in tests should use this.
+ */
+export async function createIntentDirectly(
+  surreal: Surreal,
+  workspaceId: string,
+  requesterId: string,
+  opts: CreateIntentOpts,
+): Promise<{ intentId: string; intentRecord: RecordId<"intent">; traceRecord: RecordId<"trace"> }> {
+  const intentId = `intent-${crypto.randomUUID()}`;
+  const intentRecord = new RecordId("intent", intentId);
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+  const requesterRecord = new RecordId("identity", requesterId);
+  const traceId = `trace-${intentId}`;
+  const traceRecord = new RecordId("trace", traceId);
+
+  await surreal.query(`CREATE $trace CONTENT $content;`, {
+    trace: traceRecord,
+    content: {
+      type: "intent_submission",
+      actor: requesterRecord,
+      workspace: workspaceRecord,
+      created_at: new Date(),
+    },
+  });
+
+  const intentContent: Record<string, unknown> = {
+    goal: opts.goal,
+    reasoning: opts.reasoning ?? "Test intent",
+    status: opts.status ?? "draft",
+    priority: opts.priority ?? 50,
+    action_spec: opts.actionSpec ?? { provider: "test", action: "test", params: {} },
+    trace_id: traceRecord,
+    requester: requesterRecord,
+    workspace: workspaceRecord,
+    created_at: new Date(),
+  };
+
+  if (opts.embedding !== undefined) intentContent.embedding = opts.embedding;
+  if (opts.evaluation !== undefined) intentContent.evaluation = opts.evaluation;
+  if (opts.budgetLimit !== undefined) intentContent.budget_limit = opts.budgetLimit;
+
+  await surreal.query(`CREATE $intent CONTENT $content;`, {
+    intent: intentRecord,
+    content: intentContent,
+  });
+
+  if (opts.taskId) {
+    const taskRecord = new RecordId("task", opts.taskId);
+    await surreal.query(
+      `RELATE $intent->triggered_by->$task SET created_at = time::now();`,
+      { intent: intentRecord, task: taskRecord },
+    );
+  }
+
+  return { intentId, intentRecord, traceRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Git Commit
+// ---------------------------------------------------------------------------
+
+export type CreateGitCommitOpts = {
+  message?: string;
+  repository?: string;
+  authorName?: string;
+  url?: string;
+};
+
+/**
+ * Creates a git_commit record directly in SurrealDB.
+ */
+export async function createGitCommitDirectly(
+  surreal: Surreal,
+  workspaceId: string,
+  sha: string,
+  opts?: CreateGitCommitOpts,
+): Promise<{ commitId: string; commitRecord: RecordId<"git_commit"> }> {
+  const commitId = `commit-${crypto.randomUUID()}`;
+  const commitRecord = new RecordId("git_commit", commitId);
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+
+  await surreal.query(
+    `CREATE $commit CONTENT $content;`,
+    {
+      commit: commitRecord,
+      content: {
+        sha,
+        repository: opts?.repository ?? "org/repo",
+        message: opts?.message ?? "chore: test commit",
+        author_name: opts?.authorName ?? "test-agent",
+        url: opts?.url,
+        workspace: workspaceRecord,
+        created_at: new Date(),
+      },
+    },
+  );
+
+  return { commitId, commitRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Decision
+// ---------------------------------------------------------------------------
+
+export type CreateDecisionOpts = {
+  summary: string;
+  rationale?: string;
+  status?: string;
+  embedding?: number[];
+  created_at?: Date;
+};
+
+/**
+ * Creates a decision record directly in SurrealDB.
+ */
+export async function createDecisionDirectly(
+  surreal: Surreal,
+  workspaceId: string,
+  opts: CreateDecisionOpts,
+): Promise<{ decisionId: string; decisionRecord: RecordId<"decision"> }> {
+  const decisionId = `decision-${crypto.randomUUID()}`;
+  const decisionRecord = new RecordId("decision", decisionId);
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+
+  await surreal.query(`CREATE $dec CONTENT $content;`, {
+    dec: decisionRecord,
+    content: {
+      summary: opts.summary,
+      rationale: opts.rationale ?? "Test decision",
+      status: opts.status ?? "confirmed",
+      workspace: workspaceRecord,
+      created_at: opts.created_at ?? new Date(),
+      updated_at: new Date(),
+      ...(opts.embedding ? { embedding: opts.embedding } : {}),
+    },
+  });
+
+  return { decisionId, decisionRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Observation
+// ---------------------------------------------------------------------------
+
+export type ObservationSeverity = "info" | "warning" | "conflict";
+export type ObservationStatus = "open" | "acknowledged" | "resolved";
+
+export type CreateObservationOpts = {
+  text: string;
+  severity: ObservationSeverity;
+  observationType?: string;
+  sourceAgent: string;
+  targetTable?: string;
+  targetId?: string;
+};
+
+/**
+ * Creates an observation record directly in SurrealDB.
+ * Optionally links to a target entity via an observes edge.
+ */
+export async function createObservationDirectly(
+  surreal: Surreal,
+  workspaceId: string,
+  opts: CreateObservationOpts,
+): Promise<{ observationId: string; observationRecord: RecordId<"observation"> }> {
+  const observationId = `obs-${crypto.randomUUID()}`;
+  const observationRecord = new RecordId("observation", observationId);
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+
+  await surreal.query(`CREATE $obs CONTENT $content;`, {
+    obs: observationRecord,
+    content: {
+      text: opts.text,
+      severity: opts.severity,
+      status: "open" as const,
+      observation_type: opts.observationType,
+      source_agent: opts.sourceAgent,
+      workspace: workspaceRecord,
+      created_at: new Date(),
+    },
+  });
+
+  if (opts.targetTable && opts.targetId) {
+    const targetRecord = new RecordId(opts.targetTable, opts.targetId);
+    await surreal.query(
+      `RELATE $obs->observes->$target SET added_at = time::now();`,
+      { obs: observationRecord, target: targetRecord },
+    );
+  }
+
+  return { observationId, observationRecord };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Observations Query
+// ---------------------------------------------------------------------------
+
+/**
+ * Queries all observations in a workspace, optionally filtered by source agent.
+ */
+export async function queryWorkspaceObservations(
+  surreal: Surreal,
+  workspaceId: string,
+  sourceAgent?: string,
+): Promise<Array<{
+  id: RecordId;
+  text: string;
+  severity: string;
+  status: string;
+  source_agent: string;
+  observation_type?: string;
+  workspace: RecordId<"workspace">;
+  created_at: string;
+  updated_at?: string;
+}>> {
+  const workspaceRecord = new RecordId("workspace", workspaceId);
+
+  type ObsRow = {
+    id: RecordId;
+    text: string;
+    severity: string;
+    status: string;
+    source_agent: string;
+    observation_type?: string;
+    workspace: RecordId<"workspace">;
+    created_at: string;
+    updated_at?: string;
+  };
+
+  if (sourceAgent) {
+    const rows = (await surreal.query(
+      `SELECT * FROM observation WHERE workspace = $ws AND source_agent = $agent ORDER BY created_at DESC;`,
+      { ws: workspaceRecord, agent: sourceAgent },
+    )) as Array<ObsRow[]>;
+    return rows[0] ?? [];
+  }
+
+  const rows = (await surreal.query(
+    `SELECT * FROM observation WHERE workspace = $ws ORDER BY created_at DESC;`,
+    { ws: workspaceRecord },
+  )) as Array<ObsRow[]>;
+  return rows[0] ?? [];
+}


### PR DESCRIPTION
## Summary

- Create `tests/acceptance/shared-fixtures.ts` as single source of truth for entity creation helpers (workspace, identity, intent, decision, observation, git commit)
- Update 4 domain-specific test kits (learning, intent, objective-behavior, observer) to compose shared helpers instead of reimplementing ~300 lines of duplicated DB queries
- Fix `ActionSpec.params` type from optional to required — prevents the schema drift bug that caused 44 test failures across 3 separate fix commits

## Test plan

- [x] `bun run typecheck` passes clean
- [x] `bun test tests/acceptance/agent-learnings/walking-skeleton.test.ts` passes
- [x] Full acceptance suite: `bun test --env-file=.env tests/acceptance/`
- [x] Verify no remaining `params?` in ActionSpec usages

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)